### PR TITLE
Если нету такого параметра, то yii по умол

### DIFF
--- a/protected/modules/social/controllers/SocialController.php
+++ b/protected/modules/social/controllers/SocialController.php
@@ -15,7 +15,7 @@ class SocialController extends YFrontController
     {
     	$service = Yii::app()->request->getQuery('service');
 
-        if (isset($service))
+        if ($service !== null)
         {
             $authIdentity = Yii::app()->eauth->getIdentity($service);
 


### PR DESCRIPTION
Если нету такого параметра, то yii по умолчанию вернет null, по этому нужно сделать проверку на это, а не на присвоение [public function getQuery($name,$defaultValue=null)](http://code.google.com/p/yii/source/browse/tags/1.1.8/framework/web/CHttpRequest.php#142)
