### PR TITLE
Авто-определение никнейма

### DIFF
--- a/protected/modules/user/controllers/PeopleController.php
+++ b/protected/modules/user/controllers/PeopleController.php
@@ -18,8 +18,16 @@ class PeopleController extends YFrontController
     // Вывод публичной страницы пользователя
     public function actionUserInfo($username = null, $mode = null)
     {
-        if ($username == null) {
-            $username = Yii::app()->user->getState('nick_name');
+        if ($username == null)
+        {
+            if ( Yii::app()->user->isAuthenticated())
+            {
+                $username = Yii::app()->user->getState('nick_name');
+            }
+            else
+            {
+                throw new CHttpException(404, Yii::t('user', 'Пользователь не найден!'));
+            }
         }
         $user = User::model()->findByAttributes(array("nick_name" => $username));
 


### PR DESCRIPTION
На страничке профиля теперь автоматически определяется никнейм текущего пользователя. Так что для залогинненых пользователей можно отображать просто ссылку <sitename>/user/people/userinfo/

И ещё такой момент. пул-реквесты лучше делать вот такие маленькие или сначала наделать немного изменений в отдельной ветке и потом их скопом реквестировать?
