### PR TITLE
Убрал @chmod($dbConfFile, 0666)

### DIFF
--- a/protected/modules/install/controllers/DefaultController.php
+++ b/protected/modules/install/controllers/DefaultController.php
@@ -268,7 +268,7 @@ class DefaultController extends YBackController
                         $form->addError('', Yii::t('install', "Не могу открыть файл '{file}' для записии!", array('{file}' => $dbConfFile)));
                     else
                     {
-                        if (fwrite($fh, $dbConfString) && fclose($fh) && @chmod($dbConfFile, 0666))
+                        if (fwrite($fh, $dbConfString) && fclose($fh))
                             $this->redirect(array('/install/default/modulesinstall'));
                         else
                             $form->addError('', Yii::t('install', "Произошла ошибка записи в файл '{file}'!", array('{file}' => $dbConfFile)));


### PR DESCRIPTION
В большинстве случаев, пользователь web, то есть тот пользователь от которого выполняется веб-сервер - не имеет прав на установку прав файлу. Мне кажется это лишнее в данном случае, если это действительно необходимо, я про установку прав - лучше всего попробовать их установить и если не получается - вывести просто как предупреждение
