### PR TITLE
Fix Problem with user component loading GiiModule

### DIFF
--- a/protected/modules/yupe/YupeModule.php
+++ b/protected/modules/yupe/YupeModule.php
@@ -56,13 +56,13 @@ class YupeModule extends YWebModule
     {
         $messages = array();
 
-        if (Yii::app()->getModule('install'))
+        if (Yii::app()->hasModule('install'))
             $messages[YWebModule::CHECK_ERROR][] =  array(
                 'type'    => YWebModule::CHECK_ERROR,
                 'message' => Yii::t('YupeModule.yupe', 'У Вас активирован модуль "Установщик", после установки системы его необходимо отключить! <a href="http://www.yiiframework.ru/doc/guide/ru/basics.module">Подробнее про Yii модули</a>'),
             );
 
-        if (Yii::app()->getModule('gii'))
+        if (Yii::app()->hasModule('gii'))
             $messages[YWebModule::CHECK_ERROR][] =  array(
                 'type'    => YWebModule::CHECK_ERROR,
                 'message' => Yii::t('YupeModule.yupe', 'У Вас активирован модуль "gii" после установки системы его необходимо отключить! <a href="http://www.yiiframework.ru/doc/guide/ru/basics.module">Подробнее про Yii модули</a>'),


### PR DESCRIPTION
For a simple check if gii is installed it does not have to be instanciated. So gii will not overwrite existing application components. 

Related issues:
yiisoft/yii#1906
yupe/yupe#381
