### PR TITLE
yupe-485 Нет переадресации при неавторизованном пользователе

### DIFF
--- a/protected/modules/user/controllers/account/LoginAction.php
+++ b/protected/modules/user/controllers/account/LoginAction.php
@@ -54,7 +54,11 @@ class LoginAction extends CAction
                     ? array($module->loginAdminSuccess)
                     : array($module->loginSuccess);
 
-                $this->controller->redirect($redirect);
+                /**
+                 * #485 Редиректим запрошенный URL (если такой был задан)
+                 * {@link CWebUser getReturnUrl}
+                 */
+                $this->controller->redirect(Yii::app()->user->getReturnUrl($redirect));
             }
             else
                 Yii::log(


### PR DESCRIPTION
добавил переход на запрашиваемую страницу,
в случае если старницы нет, переход произойдет на $redirect в зависимости от класса пользователя (isSuperUser)

closes #485
