### PR TITLE
Исправление выпадающего меню Bootstrap (подсветка заголовков групп в мен...

### DIFF
--- a/protected/modules/yupe/views/assets/css/styles.css
+++ b/protected/modules/yupe/views/assets/css/styles.css
@@ -109,10 +109,14 @@ footer {
     top: 11px;
     left: -6px;
 }
-.dropdown-menu li:hover {
+.dropdown-menu li:hover > [class^="nav-header"] {
     color: white;
     text-decoration: none;
     background-color: #08C;
+}
+.dropdown .dropdown-menu .nav-header {
+    margin-left: 0px;
+    margin-right: 0px;
 }
 pre .label{
     white-space: normal !important;


### PR DESCRIPTION
Исправление выпадающего меню Bootstrap (подсветка заголовков групп в меню).

На сколько я увидел, в styles.css идёт переопределение классов bootstrap при помощи !important. Пока я не решусь судить единственное ли это решение, потому предлагаю небольшую доработку, чтобы исправить отображение меню.
