### PR TITLE
Переделал вывод древовидных категорий

### DIFF
--- a/protected/modules/blog/views/blogBackend/_form.php
+++ b/protected/modules/blog/views/blogBackend/_form.php
@@ -39,7 +39,7 @@ $form = $this->beginWidget(
     <?php echo $form->errorSummary($model); ?>
 
     <div class="row-fluid control-group <?php echo $model->hasErrors('category_id') ? 'error' : ''; ?>">
-        <?php echo $form->dropDownListRow($model, 'category_id', CHtml::listData($this->module->getCategoryList(),'id','name') , array('empty' => Yii::t('BlogModule.blog','--choose--'),'class' => 'popover-help span7', 'maxlength' => 11,'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'))); ?>
+        <?php echo $form->dropDownListRow($model, 'category_id', Category::model()->getFormattedList(), array('empty' => Yii::t('BlogModule.blog','--choose--'),'class' => 'popover-help span7', 'maxlength' => 11,'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'), 'encode' => false)); ?>
     </div>
 
     <div class="wide row-fluid control-group <?php echo ($model->hasErrors('type') || $model->hasErrors('status')) ? 'error' : ''; ?>">

--- a/protected/modules/catalog/views/catalogBackend/_form.php
+++ b/protected/modules/catalog/views/catalogBackend/_form.php
@@ -36,7 +36,7 @@ $form = $this->beginWidget('bootstrap.widgets.TbActiveForm', array(
         </div>
     </div>
     <div class="row-fluid control-group <?php echo $model->hasErrors('category_id') ? 'error' : ''; ?>">
-        <?php echo $form->dropDownListRow($model, 'category_id', CHtml::listData($this->module->getCategoryList(), 'id', 'name'), array('empty' => Yii::t('CatalogModule.catalog', '--choose--'), 'class' => 'span7 popover-help', 'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'))); ?>
+        <?php echo $form->dropDownListRow($model, 'category_id', Category::model()->getFormattedList(), array('empty' => Yii::t('CatalogModule.catalog', '--choose--'), 'class' => 'span7 popover-help', 'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'), 'encode' => false)); ?>
     </div>
     <div class="row-fluid control-group <?php echo $model->hasErrors('name') ? 'error' : ''; ?>">
         <?php echo $form->textFieldRow($model, 'name', array('class' => 'span7 popover-help', 'size' => 60, 'maxlength' => 250, 'data-original-title' => $model->getAttributeLabel('name'), 'data-content' => $model->getAttributeDescription('name'))); ?>

--- a/protected/modules/category/models/Category.php
+++ b/protected/modules/category/models/Category.php
@@ -189,6 +189,24 @@ class Category extends YModel
         return CHtml::listData($category, 'id', 'name');
     }
 
+	public function getFormattedList($parent_id = null, $level = 0)
+	{
+		$categories = Category::model()->findAllByAttributes(array('parent_id' => $parent_id));
+
+		$list = array();
+
+		foreach ($categories as $key => $category)
+		{
+			$category->name = str_repeat('&emsp;', $level) . $category->name;
+
+			$list[$category->id] = $category->name;
+
+			$list = CMap::mergeArray($list, $this->getFormattedList($category->id, $level + 1));
+		}
+
+		return $list;
+	}
+
     public function getParentName()
     {
         if ($this->parent_id)

--- a/protected/modules/category/views/categoryBackend/_form.php
+++ b/protected/modules/category/views/categoryBackend/_form.php
@@ -43,7 +43,7 @@ $form = $this->beginWidget('bootstrap.widgets.TbActiveForm', array(
     <?php endif;?>
 
     <div class='row-fluid control-group <?php echo $model->hasErrors("parent_id") ? "error" : ""; ?>'>
-        <?php echo  $form->dropDownListRow($model, 'parent_id', CHtml::listData(Category::model()->findAll(), 'id', 'name'), array('empty' => Yii::t('CategoryModule.category', '--no--'),'class' => 'span7')); ?>
+        <?php echo  $form->dropDownListRow($model, 'parent_id', Category::model()->getFormattedList(), array('empty' => Yii::t('CategoryModule.category', '--no--'),'class' => 'span7', 'encode' => false)); ?>
     </div>
     <div class='control-group <?php echo $model->hasErrors("name") ? "error" : ""; ?>'>
         <?php echo $form->textFieldRow($model, 'name', array('class' => 'span7', 'maxlength' => 250)); ?>

--- a/protected/modules/image/views/imageBackend/_form.php
+++ b/protected/modules/image/views/imageBackend/_form.php
@@ -27,7 +27,7 @@ $form = $this->beginWidget(
     <?php echo $form->errorSummary($model); ?>
 
     <div class='row-fluid control-group <?php echo $model->hasErrors("category_id") ? "error" : ""; ?>'>
-        <?php echo $form->dropDownListRow($model, 'category_id', CHtml::listData($this->module->getCategoryList(), 'id', 'name'), array('empty' => Yii::t('ImageModule.image', '--choose--'))); ?>
+        <?php echo $form->dropDownListRow($model, 'category_id', Category::model()->getFormattedList(), array('empty' => Yii::t('ImageModule.image', '--choose--'), 'encode' => false)); ?>
     </div>
     <?php if (Yii::app()->hasModule('gallery')) : ?>
     <div class='row-fluid control-group <?php echo $model->hasErrors("galleryId") ? "error" : ""; ?>'>

--- a/protected/modules/news/views/newsBackend/_form.php
+++ b/protected/modules/news/views/newsBackend/_form.php
@@ -59,7 +59,7 @@ $form = $this->beginWidget('bootstrap.widgets.TbActiveForm', array(
     </div>
 
     <div class="row-fluid control-group <?php echo $model->hasErrors('category_id') ? 'error' : ''; ?>">
-        <?php echo $form->dropDownListRow($model, 'category_id', CHtml::listData($this->module->getCategoryList(), 'id', 'name'), array('class' => 'span7 popover-help','empty' => Yii::t('NewsModule.news', '--choose--'))); ?>
+        <?php echo $form->dropDownListRow($model, 'category_id', Category::model()->getFormattedList(), array('class' => 'span7 popover-help','empty' => Yii::t('NewsModule.news', '--choose--'), 'encode' => false)); ?>
     </div>
 
     <div class="row-fluid control-group <?php echo $model->hasErrors('title') ? 'error' : ''; ?>">

--- a/protected/modules/page/views/pageBackend/_form.php
+++ b/protected/modules/page/views/pageBackend/_form.php
@@ -83,7 +83,7 @@ $form = $this->beginWidget(
 
     <div class="wide row-fluid control-group <?php echo ($model->hasErrors('category_id') || $model->hasErrors('parent_id')) ? 'error' : ''; ?>">
         <div class="span4">
-            <?php echo $form->dropDownListRow($model, 'category_id', CHtml::listData($this->module->getCategoryList(), 'id', 'name'), array('empty' => Yii::t('PageModule.page', '--choose--'), 'class' => 'span7 popover-help', 'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'))); ?>
+            <?php echo $form->dropDownListRow($model, 'category_id', Category::model()->getFormattedList(), array('empty' => Yii::t('PageModule.page', '--choose--'), 'class' => 'span7 popover-help', 'data-original-title' => $model->getAttributeLabel('category_id'), 'data-content' => $model->getAttributeDescription('category_id'), 'encode' => false)); ?>
         </div>
         <div class="span3">
             <?php echo $form->dropDownListRow($model, 'parent_id', $pages, array('empty' => Yii::t('PageModule.page', '--choose--'), 'class' => 'span7 popover-help', 'data-original-title' => $model->getAttributeLabel('parent_id'), 'data-content' => $model->getAttributeDescription('parent_id'))); ?>


### PR DESCRIPTION
Дико бесило, что категории, которые в принципе древовидные, отображались просто списком. Ладно, если их было <5, но когда 20, 30, 50 — разобрать невозможно, переделал, сейчас выглядят так:

![categories at yupe](https://f.cloud.github.com/assets/2368902/1352914/c3dcef34-373d-11e3-8b42-6ed8dddadd28.png)

У этого подхода есть несколько минусов:
- Нужно в каждом поле добавлять

```
'encode' => false
```

В принципе ничего страшного, это делается 1 раз и только в админке.
- Можно было сделать ещё круче:
  ![right_way_to_select](https://f.cloud.github.com/assets/2368902/1352933/23b254bc-373e-11e3-808a-de1cb043646c.png)

Но из-за шрифта или его размера вертикальная черта вставала криво, терялась наглядность, а переделывать стили не хотелось бы.
- Генерируется новый запрос для каждой ветки. В принципе в бекенде это не так страшно, но можно было бы закешировать. Только не знаю как. Времени последнего изменения нет, может быть по кол-ву? Есть идеи?

В любом случае, мне кажется что такое отображение куда лучше, чем просто вывод списка. Что думаете?
