### PR TITLE
add facebook-sdk to composer and add rule to birth_date to allow null val

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,8 +75,7 @@
         "clevertech/yii-booster": "2.0.*",
         "yiiext/nested-set-behavior": "dev-master",
         "yiiext/imperavi-redactor-widget": "dev-master",
-        "zhuravljov/yii2-debug": "dev-master",
-        "facebook/php-sdk": "3.*"
+        "zhuravljov/yii2-debug": "dev-master"
     },
     "require-dev": {
         "codeception/codeception": "1.6.*"


### PR DESCRIPTION
Codeception требует facebook-sdk в композере
Во время установки при создании юзера вот такая ошибка была http://coment.me/pEL52k_
