### PR TITLE
fix gitignore, some where it's ignore himself

### DIFF
--- a/protected/config/modules/.gitignore
+++ b/protected/config/modules/.gitignore
@@ -1,2 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
 !.gitignore

--- a/protected/config/modulesBack/.gitignore
+++ b/protected/config/modulesBack/.gitignore
@@ -1,2 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
 !.gitignore

--- a/protected/config/userspace/.gitignore
+++ b/protected/config/userspace/.gitignore
@@ -1,2 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
 !.gitignore

--- a/protected/runtime/.gitignore
+++ b/protected/runtime/.gitignore
@@ -1,1 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
+!.gitignore

--- a/public/assets/.gitignore
+++ b/public/assets/.gitignore
@@ -1,2 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
 !.gitignore

--- a/vendor/.gitignore
+++ b/vendor/.gitignore
@@ -1,1 +1,4 @@
+# Ignore everything in this directory
 *
+# Except this file
+!.gitignore


### PR DESCRIPTION
I had some problem when clone private yupe-based project to another computer. Folder's vendor and runtime does't exist. This commit fixes it.
