### PR TITLE
Пустые поля при выборе языка, после установки

### DIFF
--- a/protected/modules/yupe/YupeModule.php
+++ b/protected/modules/yupe/YupeModule.php
@@ -39,7 +39,7 @@ class YupeModule extends WebModule
     public $uploadPath = 'uploads';
     public $email;
 
-    public $availableLanguages = 'ru, en, zh_cn';
+    public $availableLanguages = 'ru,en,zh_cn';
     public $defaultLanguage = 'ru';
     public $defaultBackendLanguage = 'ru';
 


### PR DESCRIPTION
Название языков написаны с пробелами, при обработке
 explode(',', $this->availableLanguages);

возвращается массив
[0]=>'ru',
[1]=>' en',
..
При сопоставление получается 'en' != ' en' и возвращает в админке вместо английского языка пустое поле
