### PR TITLE
Add install by default for social

### DIFF
--- a/protected/modules/social/SocialModule.php
+++ b/protected/modules/social/SocialModule.php
@@ -73,4 +73,9 @@ class SocialModule extends WebModule
     {
         parent::init();
     }
+
+	public function getIsInstallDefault()
+	{
+		return true;
+	}
 }


### PR DESCRIPTION
Если не установить модуль Social, то на странице авторизации будет валиться ошибка.
В предложенном реквесте модуль social помечается как рекомендуемый для инсталяции.
