### PR TITLE
Перенос сохранения настроек модулей в модель Settings

### DIFF
--- a/protected/modules/yupe/controllers/BackendController.php
+++ b/protected/modules/yupe/controllers/BackendController.php
@@ -299,7 +299,7 @@ class BackendController extends yupe\components\controllers\BackController
      **/
     public function saveParamsSetting($moduleId, $params)
     {    	
-    	$param_values = array();
+    	$paramValues = array();
 
     	// Перебираем все параметры модуля
     	foreach ($params as $param_name) {
@@ -307,12 +307,12 @@ class BackendController extends yupe\components\controllers\BackController
     		// Если параметр есть в post-запросе добавляем его в массив
     		if ($param_value !== null)
     		{
-    			$param_values[$param_name] = $param_value;    			
+    			$paramValues[$param_name] = $param_value;    			
     		}    		
     	}    	
     	
     	// Запускаем сохранение параметров
-    	return Settings::model()->saveModuleSettings($moduleId, $param_values);
+    	return Settings::model()->saveModuleSettings($moduleId, $paramValues);
     }
 
     /**

--- a/protected/modules/yupe/models/Settings.php
+++ b/protected/modules/yupe/models/Settings.php
@@ -196,28 +196,32 @@ class Settings extends YModel
      * @param mixed $params Массив параметров и значений которые следует сохранить (param_name => param_value)
      * 
      */
-    public function saveModuleSettings($moduleId, $param_values)
+    public function saveModuleSettings($moduleId, $paramValues)
     {
-    	foreach ($param_values as $param_name=>$value)
+    	foreach ($paramValues as $name=>$value)
     	{
     		// Получаем настройку
-    		$setting = Settings::model()->find('module_id = :module_id and param_name = :param_name', array(':module_id'=>$moduleId, ':param_name'=>$param_name));
+    		$setting = Settings::model()->find('module_id = :module_id and param_name = :param_name', array(':module_id'=>$moduleId, ':param_name'=>$name));
     		    		   		
     		// Если новая запись
     		if ($setting == null)
     		{
     			$setting = new Settings();
     			$setting->module_id = $moduleId;
-    			$setting->param_name = $param_name;
+    			$setting->param_name = $name;
     		}
     		// Если значение не изменилось то не сохраняем
-    		elseif ($setting->param_value == $value) continue;
+    		else
+    		if ($setting->param_value == $value)
+    		{
+    			continue;
+    		}
     		
     		// Присваиваем новое значение
     		$setting->param_value = $value;
     		
     		// Добавляем для параметра его правила валидации
-    		$setting->rulesFromModule = Yii::app()->getModule($moduleId)->getRulesForParam($param_name);
+    		$setting->rulesFromModule = Yii::app()->getModule($moduleId)->getRulesForParam($name);
     		
     		//Сохраняем
     		if (!$setting->save()) {


### PR DESCRIPTION
Не нашел удобного метода для сохранения настроек yupe_settings, сейчас это реализовано через BackendController, что исключает возможность грамотного сохранения из консоли или модели проекта.

Вынес сохранение параметров в модель Settings->saveModuleSettings.
Переписал BackendController->saveParamsSetting на использование этого метода.
