### PR TITLE
Загрузка файлов с одним и тем же именем

### DIFF
--- a/protected/modules/yupe/components/behaviors/FileUploadBehavior.php
+++ b/protected/modules/yupe/components/behaviors/FileUploadBehavior.php
@@ -119,9 +119,10 @@ class FileUploadBehavior extends CActiveRecordBehavior
 
     public function beforeSave($event)
     {
-        if ($this->checkScenario() && $this->_newFile instanceof CUploadedFile) {
+        if ($this->checkScenario() && $this->_newFile instanceof CUploadedFile) {      	
+        	$this->removeFile();
             $this->saveFile();
-            $this->removeFile();
+            
         }
 
         return parent::beforeSave($event);


### PR DESCRIPTION
До этих правок загрузка файла с именем уже существующего файла была невозможна, т.к. он затирался после загрузки.
