### PR TITLE
rbac. Рефакторинг построения иерархии ролей

### DIFF
--- a/protected/modules/rbac/RbacModule.php
+++ b/protected/modules/rbac/RbacModule.php
@@ -19,7 +19,7 @@ class RbacModule extends WebModule
 
     public function getAdminPageLink()
     {
-        return '/rbac/rbacBackend/index';
+        return '/rbac/rbacBackend/assign';
     }
 
     public function getNavigation()
@@ -50,12 +50,12 @@ class RbacModule extends WebModule
 
     public function getAuthor()
     {
-        return Yii::t('RbacModule.rbac', 'amylabs team / Dark_Cs');
+        return Yii::t('RbacModule.rbac', 'amylabs team');
     }
 
     public function getAuthorEmail()
     {
-        return 'hello@amylabs.ru / darkcs2@gmail.com';
+        return 'hello@amylabs.ru';
     }
 
     public function getUrl()

--- a/protected/modules/rbac/components/RbacTree.php
+++ b/protected/modules/rbac/components/RbacTree.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * Класс для построения частично упорядоченной иерархии ролей для вывода в виджете CTreeView
+ * Class RbacTree
+ */
+class RbacTree
+{
+    /**
+     * @var array - правила, сгруппированыые по типам, формат array(2 => array(), 1 => array(), 0 => array())
+     */
+    private $itemsGroupedByTypes = array();
+    /**
+     * @var array - список правил в формате name => AuthItem object
+     */
+    private $itemsList = array();
+    /**
+     * @var array - связи элементов в формате itemName => array(itemName1, itemName2)
+     */
+    private $hierarchy = array();
+    /**
+     * @var array - список ролей, которые были в иерархии в качестве потомков
+     */
+    private $wereChildren = array();
+
+    /**
+     * @var User - пользователь, для которого строится дерево
+     */
+    private $user;
+
+    /* кэш для доступности роли, формат 'name' => value */
+    private $permissionList = array();
+
+    public function __construct($user = null)
+    {
+        $this->user = $user ?: Yii::app()->user;
+        $this->getData();
+    }
+
+    /**
+     * Загрузка данных из бд и распределение их по спискам
+     */
+    private function getData()
+    {
+        $userAssign = CHtml::listData(AuthAssignment::model()->findAllByAttributes(array('userid' => $this->user->id)), 'itemname', 'userid');
+        $authItems = AuthItem::model()->findAll(array('order' => 'type DESC, description ASC'));
+        foreach ($authItems as $item) {
+            $this->itemsGroupedByTypes[$item->type][$item->name] = $item;
+            $this->itemsList[$item->name] = $item;
+            // если проверять каждый элемент, то генерируется огромное количество запросов, но получается правильное дерево с отмеченными дочерними элементами
+            // созможно стоит при сохранении ролей что-то придумать
+            $this->permissionList[$item->name] = isset($userAssign[$item->name]); //Yii::app()->authManager->checkAccess($item->name, $this->user->id);
+        }
+        $authItemsChild = AuthItemChild::model()->findAll();
+        foreach ($authItemsChild as $item) {
+            $this->hierarchy[$item->parent][] = $item->child;
+            $this->wereChildren[] = $item->child;
+        }
+    }
+
+    /**
+     * Построение дерева, в качестве root узлов которого выступает указанный тип элементов.
+     * Каждая элемент будет иметь свой корневой узел, в независимости от того был ли он включен в другой элемент.
+     * @param $type int - роль - 2, задача - 1, операция - 0
+     * @return array
+     */
+    private function getTextTree($type)
+    {
+        $tree = array();
+        foreach ($this->itemsGroupedByTypes[$type] as $name => $item) {
+            $tree[] = $this->getTextNode($name);
+        }
+        return $tree;
+    }
+
+    /**
+     * Рекурсивно формирует узел дерева вместе с потомками
+     * @param $itemName string - Название роли
+     * @return array
+     */
+    private function getTextNode($itemName)
+    {
+        $children = $this->getTextItemChildren($itemName);
+        return array(
+            'text' => $this->getTextItem($this->itemsList[$itemName]),
+            'children' => $children,
+        );
+    }
+
+    /**
+     * Получает список потомков роли в виде уже готовых узлов для дерева
+     * @param $name - Название роли
+     * @return array
+     */
+    private function getTextItemChildren($name)
+    {
+        $res = array();
+        foreach ($this->hierarchy as $key => $items) {
+            if ($key == $name) {
+                foreach ($items as $item) {
+                    $res[] = $this->getTextNode($item);
+                }
+            }
+        }
+        return $res;
+    }
+
+    /**
+     * Генерирует html для вставки в качестве текста в узел CTreeView
+     * @param $item AuthItem
+     * @return string
+     */
+    private function getTextItem($item)
+    {
+        return CHtml::label(
+            CHtml::checkBox(
+                'AuthItem[]',
+                $this->permissionList[$item['name']],
+                array('class' => 'auth-item', 'value' => $item['name'], 'id' => 'auth-item-' . uniqid())
+            ) . $this->getItemDescription($item),
+            null,
+            array('class' => 'checkbox')
+        );
+    }
+
+    private function getItemDescription($item)
+    {
+        return $item->description . " ({$item->getType()} <span class='muted'>{$item->name}</span>)";
+    }
+
+    /**
+     * Строит дерево для указанного типа элементов с учетом их упоминания в качестве потомков у других элементов.
+     * Если элемент был потом для каких-то узлов, то он не будет иметь своего корневого узла.
+     * @param $type
+     * @return array
+     */
+    private function getTreeForUnusedElements($type)
+    {
+        $tree = array();
+        // цикл идет по элементам определенной роли, которые не были упомянуты в качестве потомков
+        foreach (array_diff(array_keys((array)$this->itemsGroupedByTypes[$type]), $this->wereChildren) as $name) {
+            $tree[] = $this->getTextNode($name);
+        }
+        return $tree;
+    }
+
+    /**
+     * Формирует готовое дерево для использования в CTreeView
+     * @return array
+     */
+    public function getTreeRoles()
+    {
+        /* вершинами дерева будут роли, задачи и операции, несвязанные с ролями не будут учтены */
+        // в этом случае каждая роль будет иметь свой root узел
+        //$textRoles = $this->getTextTree(AuthItem::TYPE_ROLE);
+
+        // а в этом роли, для которых есть родитель, будут только в родителях
+        $textRoles = $this->getTreeForUnusedElements(AuthItem::TYPE_ROLE);
+
+        // задачи/операции строятся через getTreeForUnusedElements для того, чтобы не повторять узлы в дереве, которые уже были использованы в ролях/задачах
+        $textTasks = $this->getTreeForUnusedElements(AuthItem::TYPE_TASK);
+        $textOperations = $this->getTreeForUnusedElements(AuthItem::TYPE_OPERATION);
+
+        $result = array_merge($textRoles, $textTasks, $textOperations);
+
+        return $result;
+    }
+
+    /**
+     * Возвращает список в формате 'name' => 'description'
+     * @param $type
+     * @return array
+     */
+    public function getItemsList($type)
+    {
+        $res = array();
+        foreach ($this->itemsGroupedByTypes[$type] as $name => $item) {
+            $res[$name] = $this->getItemDescription($item);
+        }
+        return $res;
+    }
+}

--- a/protected/modules/rbac/install/rbac.php
+++ b/protected/modules/rbac/install/rbac.php
@@ -12,6 +12,6 @@
         ),
     ),
     'rules' => array(
-        '/backend/rbac/<controller:\w+>/<action:\w+>/<id:\w+._->' => 'rbac/<controller>Backend/<action>',
+        '/backend/rbac/<controller:\w+>/<action:\w+>/<id:[\w._-]+>' => 'rbac/<controller>Backend/<action>',
     ),
 );

--- a/protected/modules/rbac/views/rbacBackend/_form.php
+++ b/protected/modules/rbac/views/rbacBackend/_form.php
@@ -39,6 +39,11 @@
             event.preventDefault();
             $('.item:visible').attr('checked', true);
         });
+
+        $('#uncheck-all').click(function (event) {
+            event.preventDefault();
+            $('.item:visible').attr('checked', false);
+        });
     });
 </script>
 
@@ -67,7 +72,7 @@
 
 
 <div class="row-fluid">
-    <?php echo $form->dropDownListRow($model, 'type', $model->getTypeList(), array('empty' => '----', 'class' => 'span5')); ?>
+    <?php echo $form->dropDownListRow($model, 'type', $model->getTypeList(), array('empty' => '---', 'class' => 'span5')); ?>
 </div>
 
 <div class="row-fluid">
@@ -77,12 +82,15 @@
 <div id="operations-list" style="display:none;">
     <p><b>Операции:</b></p>
     <?php echo CHtml::textField('search', '', array('class' => 'span5', 'placeholder' => 'Фильтр')); ?>
-    <div><?php echo CHtml::link(Yii::t('RbacModule.rbac', 'Выбрать все'), '#', array('id' => 'check-all')); ?></div>
+    <p>
+        <?php echo CHtml::link(Yii::t('RbacModule.rbac', 'Выбрать все'), '#', array('id' => 'check-all')); ?>
+        <?php echo CHtml::link(Yii::t('RbacModule.rbac', 'Очистить все'), '#', array('id' => 'uncheck-all')); ?>
+    </p>
     <?php foreach ($operations as $k => $v): ?>
         <div class="row-fluid operation">
             <div class="span7">
                 <label class="checkbox">
-                    <?php echo CHtml::checkBox('operations[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
+                    <?php echo CHtml::checkBox('ChildAuthItems[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
                     <?php echo $v;?>
                 </label>
             </div>
@@ -96,7 +104,7 @@
         <div class="row-fluid operation">
             <div class="span7">
                 <label class="checkbox">
-                    <?php echo CHtml::checkBox('tasks[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
+                    <?php echo CHtml::checkBox('ChildAuthItems[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
                     <?php echo $v;?>
                 </label>
             </div>
@@ -110,7 +118,7 @@
         <div class="row-fluid operation">
             <div class="span7">
                 <label class="checkbox">
-                    <?php echo CHtml::checkBox('roles[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
+                    <?php echo CHtml::checkBox('ChildAuthItems[]', isset($checkedList[$k]), array('class' => 'item', 'value' => $k, 'id' => $k)); ?>
                     <?php echo $v;?>
                 </label>
             </div>

--- a/protected/modules/rbac/views/rbacBackend/assign.php
+++ b/protected/modules/rbac/views/rbacBackend/assign.php
@@ -1,9 +1,19 @@
 <script type="text/javascript">
     $(document).ready(function () {
-        $('input.root').click(function () {
-            var data = $(this).is(':checked') ? true : false;
-            $(this).closest('li').find('input').attr('checked', data);
+        function changeChildNodes(elem) {
+            $(elem).closest('li').find('input').attr('checked', elem.checked);
+        }
+
+        $('input.auth-item').change(function () {
+            // смысл этой ужасной конструкции в том, чтобы ветки с одинаковыми именами отключались и включались согласованно
+            // нужно сделать, чтобы и при выборе родительского узла для всех дочерних происходило тоже самое и выключались
+            // узлы в других ролях
+            $('input[value="' + this.value + '"]:not(#' + this.id + ')').attr('checked', this.checked).closest('li').find('input').attr('checked', this.checked);
+            changeChildNodes(this);
         });
+
+        // для того, чтобы дерево было развернуто только до второго уровня, как сделать это нормально не ясно
+        setTimeout(function () {$('ul.treeview > li > div.hitarea').click();}, 200);
     });
 </script>
 
@@ -27,7 +37,7 @@ $form = $this->beginWidget(
 
 ?>
 
-<?php $this->widget('CTreeView', array('data' => $tree)); ?>
+<?php $this->widget('CTreeView', array('data' => $tree, 'collapsed' => true)); ?>
 
 <div class="form-actions">
     <?php

--- a/protected/modules/yupe/filters/YBackAccessControl.php
+++ b/protected/modules/yupe/filters/YBackAccessControl.php
@@ -26,41 +26,21 @@ class YBackAccessControl extends CAccessControlFilter
             throw new CHttpException(404);
         }
 
-        if (Yii::app()->user->isSuperUser()) {
+        if (Yii::app()->user->isSuperUser() || Yii::app()->hasModule('rbac')) {
             return true;
         }
 
-        if (Yii::app()->user->isGuest)
-        {
-            Yii::app()->user->loginUrl = array('/user/account/backendlogin');
-        }
+        Yii::app()->user->loginUrl = array('/user/account/backendlogin');
 
-        // если включен rbac, то он сам разберется какие страницы показывать
-        if (Yii::app()->hasModule('rbac'))
-        {
-            return true;
-        }
-        else
-        {
-            if (Yii::app()->user->isGuest)
-            {
-                if ($filterChain->controller->yupe->hidePanelUrls == WebModule::CHOICE_YES)
-                {
-                    throw new CHttpException(404);
-                }
-                Yii::app()->getUser()->setReturnUrl(Yii::app()->getRequest()->getUrl());
-                $filterChain->controller->redirect(array('/user/account/backendlogin'));
+        if (Yii::app()->user->isGuest) {
+            if ($filterChain->controller->yupe->hidePanelUrls == WebModule::CHOICE_YES) {
+                throw new CHttpException(404);
             }
-            else
-            {
-                // если пользователь авторизован, но не администратор, перекинем его на страницу для разлогиневшегося пользователя
-                $filterChain->controller->redirect(Yii::app()->createAbsoluteUrl(Yii::app()->getModule('user')->logoutSuccess));
-            }
-            // не ясен смысл этой конструкции, если это где-то использовалось, то надо там переделать получение ответа
-            /*if (Yii::app()->getRequest()->getIsAjaxRequest())
-            {
-                Yii::app()->ajax->failure(Yii::t('YupeModule.yupe', 'Session expired...'));
-            }*/
+            Yii::app()->getUser()->setReturnUrl(Yii::app()->getRequest()->getUrl());
+            $filterChain->controller->redirect(array('/user/account/backendlogin'));
+        } else {
+            // если пользователь авторизован, но не администратор, перекинем его на страницу для разлогиневшегося пользователя
+            $filterChain->controller->redirect(Yii::app()->createAbsoluteUrl(Yii::app()->getModule('user')->logoutSuccess));
         }
     }
 }


### PR DESCRIPTION
Перенес построение дерева ролей во вспомогательный класс. Теперь граф ролей разворачивается в дерево с копированием элементов, то есть примерно такая картина получается:
![](http://i.imgur.com/dFz26vJ.png)
что упрощает навигацию по дереву, роли не разбросаны кусками по всему дереву, а строится полноценная структура для каждого независимого узла. И немного почистил контроллер.
