### PR TITLE
Полные имена классов у иконок модулей

### DIFF
--- a/protected/modules/blog/BlogModule.php
+++ b/protected/modules/blog/BlogModule.php
@@ -106,16 +106,16 @@ class BlogModule extends yupe\components\WebModule
     {
         return array(
             array('label' => Yii::t('BlogModule.blog', 'Blogs')),
-            array('icon' => 'list-alt', 'label' => Yii::t('BlogModule.blog', 'Blog list'), 'url' => array('/blog/blogBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('BlogModule.blog', 'New blog'), 'url' => array('/blog/blogBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('BlogModule.blog', 'Blog list'), 'url' => array('/blog/blogBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('BlogModule.blog', 'New blog'), 'url' => array('/blog/blogBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('BlogModule.blog', 'Blogs categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
             array('label' => Yii::t('BlogModule.blog', 'Posts')),
-            array('icon' => 'list-alt', 'label' => Yii::t('BlogModule.blog', 'Post list'), 'url' => array('/blog/postBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('BlogModule.blog', 'New post'), 'url' => array('/blog/postBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('BlogModule.blog', 'Post list'), 'url' => array('/blog/postBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('BlogModule.blog', 'New post'), 'url' => array('/blog/postBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('BlogModule.blog', 'Posts categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
             array('label' => Yii::t('BlogModule.blog', 'Members')),
-            array('icon' => 'list-alt', 'label' => Yii::t('BlogModule.blog', 'Member list'), 'url' => array('/blog/userToBlogBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('BlogModule.blog', 'New member'), 'url' => array('/blog/userToBlogBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('BlogModule.blog', 'Member list'), 'url' => array('/blog/userToBlogBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('BlogModule.blog', 'New member'), 'url' => array('/blog/userToBlogBackend/create')),
         );
     }
 
@@ -156,7 +156,7 @@ class BlogModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "pencil";
+        return "fa fa-fw fa-pencil";
     }
 
     /**

--- a/protected/modules/catalog/CatalogModule.php
+++ b/protected/modules/catalog/CatalogModule.php
@@ -89,8 +89,8 @@ class CatalogModule extends WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('CatalogModule.catalog', 'Product list'), 'url' => array('/catalog/catalogBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('CatalogModule.catalog', 'Add a product'), 'url' => array('/catalog/catalogBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('CatalogModule.catalog', 'Product list'), 'url' => array('/catalog/catalogBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('CatalogModule.catalog', 'Add a product'), 'url' => array('/catalog/catalogBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('CatalogModule.catalog', 'Goods categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
         );
     }
@@ -137,7 +137,7 @@ class CatalogModule extends WebModule
 
     public function getIcon()
     {
-        return 'shopping-cart';
+        return 'fa fa-fw fa-shopping-cart';
     }
 
     public function init()

--- a/protected/modules/category/CategoryModule.php
+++ b/protected/modules/category/CategoryModule.php
@@ -106,7 +106,7 @@ class CategoryModule extends WebModule
 
     public function getIcon()
     {
-        return 'folder-open';
+        return 'fa fa-fw fa-folder-open';
     }
 
     public function isMultiLang()
@@ -127,8 +127,8 @@ class CategoryModule extends WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('CategoryModule.category', 'Categories list'), 'url' => array('/category/categoryBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('CategoryModule.category', 'Create category'), 'url' => array('/category/categoryBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('CategoryModule.category', 'Categories list'), 'url' => array('/category/categoryBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('CategoryModule.category', 'Create category'), 'url' => array('/category/categoryBackend/create')),
         );
     }
 

--- a/protected/modules/comment/CommentModule.php
+++ b/protected/modules/comment/CommentModule.php
@@ -157,14 +157,14 @@ class CommentModule extends WebModule
 
     public function getIcon()
     {
-        return "comment";
+        return "fa fa-fw fa-comment";
     }
     
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('CommentModule.comment', 'Comments list'), 'url'=>array('/comment/commentBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('CommentModule.comment', 'Create comment'), 'url' => array('/comment/commentBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('CommentModule.comment', 'Comments list'), 'url'=>array('/comment/commentBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('CommentModule.comment', 'Create comment'), 'url' => array('/comment/commentBackend/create')),
         );
     }
 

--- a/protected/modules/contentblock/ContentBlockModule.php
+++ b/protected/modules/contentblock/ContentBlockModule.php
@@ -51,7 +51,7 @@ class ContentBlockModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "th-large";
+        return "fa fa-fw fa-th-large";
     }
 
     public function init()
@@ -74,12 +74,12 @@ class ContentBlockModule extends yupe\components\WebModule
     {
         return array(
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('ContentBlockModule.contentblock', 'Blocks list'),
                 'url' => array('/contentblock/contentBlockBackend/index')
             ),
             array(
-                'icon' => 'plus-sign',
+                'icon' => 'icon-plus-sign',
                 'label' => Yii::t('ContentBlockModule.contentblock', 'Add block'),
                 'url' => array('/contentblock/contentBlockBackend/create')
             ),

--- a/protected/modules/dictionary/DictionaryModule.php
+++ b/protected/modules/dictionary/DictionaryModule.php
@@ -55,7 +55,7 @@ class DictionaryModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "book";
+        return "fa fa-fw fa-book";
     }
 
     public function getVersion()
@@ -72,11 +72,11 @@ class DictionaryModule extends yupe\components\WebModule
     {
         return array(
             array('label' => Yii::t('DictionaryModule.dictionary', 'Dictionaries')),
-            array('icon' => 'list-alt', 'label' => Yii::t('DictionaryModule.dictionary', 'Dictionaries list'), 'url' => array('/dictionary/dictionaryBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('DictionaryModule.dictionary', 'Create dictionary'), 'url' => array('/dictionary/dictionaryBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('DictionaryModule.dictionary', 'Dictionaries list'), 'url' => array('/dictionary/dictionaryBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('DictionaryModule.dictionary', 'Create dictionary'), 'url' => array('/dictionary/dictionaryBackend/create')),
             array('label' => Yii::t('DictionaryModule.dictionary', 'Items')),
-            array('icon' => 'list-alt', 'label' => Yii::t('DictionaryModule.dictionary', 'Items list'), 'url' => array('/dictionary/dictionaryDataBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('DictionaryModule.dictionary', 'Create item'), 'url' => array('/dictionary/dictionaryDataBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('DictionaryModule.dictionary', 'Items list'), 'url' => array('/dictionary/dictionaryDataBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('DictionaryModule.dictionary', 'Create item'), 'url' => array('/dictionary/dictionaryDataBackend/create')),
         );
     }
 

--- a/protected/modules/docs/DocsModule.php
+++ b/protected/modules/docs/DocsModule.php
@@ -134,8 +134,8 @@ class DocsModule extends yupe\components\WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('DocsModule.docs', 'Show local files'), 'url' => array('/docs/docsBackend/index')),
-            array('icon' => 'list-alt', 'label' => Yii::t('DocsModule.docs', 'Local docs'), 'url' => array('/docs/show/index')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('DocsModule.docs', 'Show local files'), 'url' => array('/docs/docsBackend/index')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('DocsModule.docs', 'Local docs'), 'url' => array('/docs/show/index')),
             array('icon' => 'icon-globe', 'label' => Yii::t('DocsModule.docs', 'Online docs'), 'url' => 'http://yupe.ru/docs/index.html?from=help','linkOptions' => array('target' => '_blank')),
         );
     }
@@ -187,7 +187,7 @@ class DocsModule extends yupe\components\WebModule
      */
     public function getIcon()
     {
-        return "book";
+        return "fa fa-fw fa-book";
     }
 
     /**

--- a/protected/modules/feedback/FeedbackModule.php
+++ b/protected/modules/feedback/FeedbackModule.php
@@ -149,8 +149,8 @@ class FeedbackModule extends WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('FeedbackModule.feedback', 'Messages list'), 'url' => array('/feedback/feedbackBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('FeedbackModule.feedback', 'Create message'), 'url' => array('/feedback/feedbackBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('FeedbackModule.feedback', 'Messages list'), 'url' => array('/feedback/feedbackBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('FeedbackModule.feedback', 'Create message'), 'url' => array('/feedback/feedbackBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('FeedbackModule.feedback', 'Messages categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
         );
     }
@@ -192,7 +192,7 @@ class FeedbackModule extends WebModule
 
     public function getIcon()
     {
-        return 'envelope';
+        return 'fa fa-fw fa-envelope';
     }
 
     /**

--- a/protected/modules/gallery/GalleryModule.php
+++ b/protected/modules/gallery/GalleryModule.php
@@ -68,7 +68,7 @@ class GalleryModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "camera";
+        return "fa fa-fw fa-camera";
     }
 
     public function getAdminPageLink()
@@ -99,12 +99,12 @@ class GalleryModule extends yupe\components\WebModule
     {
         return array(
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('GalleryModule.gallery', 'Galleries list'),
                 'url' => array('/gallery/galleryBackend/index')
             ),
             array(
-                'icon' => 'plus-sign',
+                'icon' => 'icon-plus-sign',
                 'label' => Yii::t('GalleryModule.gallery', 'Create gallery'),
                 'url' => array('/gallery/galleryBackend/create')
             ),

--- a/protected/modules/homepage/HomepageModule.php
+++ b/protected/modules/homepage/HomepageModule.php
@@ -100,7 +100,7 @@ class HomepageModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return 'home';
+        return 'fa fa-fw fa-home';
     }
 
     public function getAdminPageLink()

--- a/protected/modules/image/ImageModule.php
+++ b/protected/modules/image/ImageModule.php
@@ -55,7 +55,7 @@ class ImageModule extends WebModule
 
     public function getIcon()
     {
-        return "picture-o";
+        return "fa fa-fw fa-picture-o";
     }
 
     public function getParamsLabels()
@@ -222,12 +222,12 @@ class ImageModule extends WebModule
     {
         return array(
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('ImageModule.image', 'Images list'),
                 'url' => array('/image/imageBackend/index')
             ),
             array(
-                'icon' => 'plus-sign',
+                'icon' => 'icon-plus-sign',
                 'label' => Yii::t('ImageModule.image', 'Add image'),
                 'url' => array('/image/imageBackend/create')
             ),

--- a/protected/modules/install/InstallModule.php
+++ b/protected/modules/install/InstallModule.php
@@ -305,7 +305,7 @@ class InstallModule extends WebModule
      **/
     public function getIcon()
     {
-        return "download-alt";
+        return "fa fa-fw fa-download-alt";
     }
 
     /**

--- a/protected/modules/mail/MailModule.php
+++ b/protected/modules/mail/MailModule.php
@@ -107,7 +107,7 @@ class MailModule extends yupe\components\WebModule
      **/
     public function getIcon()
     {
-        return 'envelope';
+        return 'fa fa-fw fa-envelope';
     }
 
     /**
@@ -129,11 +129,11 @@ class MailModule extends yupe\components\WebModule
     {
         return array(
             array('label' => Yii::t('MailModule.mail', 'Mail events')),
-            array('icon' => 'list-alt', 'label' => Yii::t('MailModule.mail', 'Messages list'), 'url'=>array('/mail/eventBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('MailModule.mail', 'Create event'), 'url' => array('/mail/eventBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('MailModule.mail', 'Messages list'), 'url' => array('/mail/eventBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('MailModule.mail', 'Create event'), 'url' => array('/mail/eventBackend/create')),
             array('label' => Yii::t('MailModule.mail', 'Mail templates')),
-            array('icon'=> 'list-alt', 'label' => Yii::t('MailModule.mail', 'Templates list'), 'url'=>array('/mail/templateBackend/index')),
-            array('icon'=> 'plus-sign', 'label' => Yii::t('MailModule.mail', 'Create template'), 'url' => array('/mail/templateBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('MailModule.mail', 'Templates list'), 'url' => array('/mail/templateBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('MailModule.mail', 'Create template'), 'url' => array('/mail/templateBackend/create')),
         );
     }
 

--- a/protected/modules/menu/MenuModule.php
+++ b/protected/modules/menu/MenuModule.php
@@ -61,7 +61,7 @@ class MenuModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "list";
+        return "fa fa-fw fa-list";
     }
 
     public function getAdminPageLink()
@@ -73,11 +73,11 @@ class MenuModule extends yupe\components\WebModule
     {
         return array(
             array('label' => Yii::t('MenuModule.menu', 'Menu')),
-            array('icon' => 'list-alt','label' => Yii::t('MenuModule.menu', 'Manage menu'), 'url' => array('/menu/menuBackend/index')),
-            array('icon' => 'plus-sign','label' => Yii::t('MenuModule.menu', 'Create menu'), 'url' => array('/menu/menuBackend/create')),
+            array('icon' => 'icon-list-alt','label' => Yii::t('MenuModule.menu', 'Manage menu'), 'url' => array('/menu/menuBackend/index')),
+            array('icon' => 'icon-plus-sign','label' => Yii::t('MenuModule.menu', 'Create menu'), 'url' => array('/menu/menuBackend/create')),
             array('label' => Yii::t('MenuModule.menu', 'Menu items')),
-            array('icon' => 'list-alt','label' => Yii::t('MenuModule.menu', 'Manage menu items'), 'url' => array('/menu/menuitemBackend/index')),
-            array('icon' => 'plus-sign','label' => Yii::t('MenuModule.menu', 'Create menu item'), 'url' => array('/menu/menuitemBackend/create')),
+            array('icon' => 'icon-list-alt','label' => Yii::t('MenuModule.menu', 'Manage menu items'), 'url' => array('/menu/menuitemBackend/index')),
+            array('icon' => 'icon-plus-sign','label' => Yii::t('MenuModule.menu', 'Create menu item'), 'url' => array('/menu/menuitemBackend/create')),
         );
     }
 

--- a/protected/modules/news/NewsModule.php
+++ b/protected/modules/news/NewsModule.php
@@ -165,7 +165,7 @@ class NewsModule extends WebModule
 
     public function getIcon()
     {
-        return "leaf";
+        return "fa fa-fw fa-leaf";
     }
 
     public function getAdminPageLink()
@@ -176,8 +176,8 @@ class NewsModule extends WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('NewsModule.news', 'News list'), 'url' => array('/news/newsBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('NewsModule.news', 'Create article'), 'url' => array('/news/newsBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('NewsModule.news', 'News list'), 'url' => array('/news/newsBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('NewsModule.news', 'Create article'), 'url' => array('/news/newsBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('NewsModule.news', 'News categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
         );
     }

--- a/protected/modules/page/PageModule.php
+++ b/protected/modules/page/PageModule.php
@@ -82,7 +82,7 @@ class PageModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "file";
+        return "fa fa-fw fa-file";
     }
 
     public function init()
@@ -113,8 +113,8 @@ class PageModule extends yupe\components\WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('PageModule.page', 'Pages list'), 'url' => array('/page/pageBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('PageModule.page', 'Create page'), 'url' => array('/page/pageBackend/create')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('PageModule.page', 'Pages list'), 'url' => array('/page/pageBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('PageModule.page', 'Create page'), 'url' => array('/page/pageBackend/create')),
             array('icon' => 'icon-folder-open', 'label' => Yii::t('PageModule.page', 'Pages categories'), 'url' => array('/category/categoryBackend/index', 'Category[parent_id]' => (int)$this->mainCategory)),
         );
     }

--- a/protected/modules/queue/QueueModule.php
+++ b/protected/modules/queue/QueueModule.php
@@ -59,7 +59,7 @@ class QueueModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return 'tasks';
+        return 'fa fa-fw fa-tasks';
     }
 
     public function getAdminPageLink()
@@ -80,9 +80,9 @@ class QueueModule extends yupe\components\WebModule
     public function getNavigation()
     {
         return array(
-            array('icon' => 'list-alt', 'label' => Yii::t('QueueModule.queue', 'Task list'), 'url' => array('/queue/queueBackend/index')),
-            array('icon' => 'plus-sign', 'label' => Yii::t('QueueModule.queue', 'Create task'), 'url' => array('/queue/queueBackend/create')),
-            array('icon' => 'trash', 'label' => Yii::t('QueueModule.queue', 'Clean queue'), 'url' => array('/queue/queueBackend/clear')),
+            array('icon' => 'icon-list-alt', 'label' => Yii::t('QueueModule.queue', 'Task list'), 'url' => array('/queue/queueBackend/index')),
+            array('icon' => 'icon-plus-sign', 'label' => Yii::t('QueueModule.queue', 'Create task'), 'url' => array('/queue/queueBackend/create')),
+            array('icon' => 'icon-trash', 'label' => Yii::t('QueueModule.queue', 'Clean queue'), 'url' => array('/queue/queueBackend/clear')),
         );
     }
 

--- a/protected/modules/rbac/RbacModule.php
+++ b/protected/modules/rbac/RbacModule.php
@@ -29,18 +29,18 @@ class RbacModule extends WebModule
         return array(
             array('label' => Yii::t('RbacModule.rbac', 'Roles')),
             array(
-                'icon' => 'user',
+                'icon' => 'icon-user',
                 'label' => Yii::t('RbacModule.rbac', 'Assign roles'),
                 'url' => array('/rbac/rbacBackend/assign')
             ),
             array(
-                'icon' => 'align-left',
+                'icon' => 'icon-align-left',
                 'label' => Yii::t('RbacModule.rbac', 'Manage operations'),
                 'url' => array('/rbac/rbacBackend/index')
             ),
             array('label' => Yii::t('RbacModule.rbac', 'RBAC')),
             array(
-                'icon' => 'magnet',
+                'icon' => 'icon-magnet',
                 'label' => Yii::t('RbacModule.rbac', 'Import RBAC'),
                 'url' => array('/rbac/rbacBackend/import')
             )
@@ -84,7 +84,7 @@ class RbacModule extends WebModule
 
     public function getIcon()
     {
-        return 'ok';
+        return 'fa fa-fw fa-check';
     }
 
     public function getDependencies()

--- a/protected/modules/social/SocialModule.php
+++ b/protected/modules/social/SocialModule.php
@@ -66,7 +66,7 @@ class SocialModule extends WebModule
 
     public function getIcon()
     {
-        return "globe";
+        return "fa fa-fw fa-globe";
     }
 
     public function getNavigation()
@@ -74,7 +74,7 @@ class SocialModule extends WebModule
         return array(
             array('label' => Yii::t('SocialModule.social', 'Users')),
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('SocialModule.social', 'Accounts'),
                 'url' => array('/social/socialBackend/index')
             ),

--- a/protected/modules/user/UserModule.php
+++ b/protected/modules/user/UserModule.php
@@ -270,18 +270,18 @@ class UserModule extends WebModule
         return array(
             array('label' => Yii::t('UserModule.user', 'Users')),
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('UserModule.user', 'Manage users'),
                 'url' => array('/user/userBackend/index')
             ),
             array(
-                'icon' => 'plus-sign',
+                'icon' => 'icon-plus-sign',
                 'label' => Yii::t('UserModule.user', 'Create user'),
                 'url' => array('/user/userBackend/create')
             ),
             array('label' => Yii::t('UserModule.user', 'Tokens')),
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('UserModule.user', 'Token list'),
                 'url' => array('/user/tokensBackend/index')
             ),
@@ -335,7 +335,7 @@ class UserModule extends WebModule
 
     public function getIcon()
     {
-        return 'user';
+        return 'fa fa-fw fa-user';
     }
 
     public function getConditions()

--- a/protected/modules/yupe/YupeModule.php
+++ b/protected/modules/yupe/YupeModule.php
@@ -478,10 +478,10 @@ class YupeModule extends WebModule
                     'class' => 'flushAction',
                     'method' => 'cacheAll',
                 ),
-                'icon' => 'trash',
+                'icon' => 'icon-trash',
                 'items' => array(
                     array(
-                        'icon' => 'trash',
+                        'icon' => 'icon-trash',
                         'label' => Yii::t('YupeModule.yupe', 'Clean settings cache'),
                         'url' => array('/yupe/backend/flushDumpSettings'),
                         'linkOptions' => array(
@@ -490,7 +490,7 @@ class YupeModule extends WebModule
                         )
                     ),
                     array(
-                        'icon' => 'trash',
+                        'icon' => 'icon-trash',
                         'label' => Yii::t('YupeModule.yupe', 'Clean cache'),
                         'url' => array('/yupe/backend/ajaxflush', 'method' => 1),
                         'linkOptions' => array(
@@ -499,7 +499,7 @@ class YupeModule extends WebModule
                         )
                     ),
                     array(
-                        'icon' => 'trash',
+                        'icon' => 'icon-trash',
                         'label' => Yii::t('YupeModule.yupe', 'Clean assets'),
                         'url' => array('/yupe/backend/ajaxflush', 'method' => 2),
                         'linkOptions' => array(
@@ -508,7 +508,7 @@ class YupeModule extends WebModule
                         )
                     ),
                     array(
-                        'icon' => 'trash',
+                        'icon' => 'icon-trash',
                         'label' => Yii::t('YupeModule.yupe', 'Clean cache and assets'),
                         'url' => array('/yupe/backend/ajaxflush', 'method' => 3),
                         'linkOptions' => array(
@@ -519,17 +519,17 @@ class YupeModule extends WebModule
                 )
             ),
             array(
-                'icon'  => "th",
+                'icon'  => "icon-th",
                 'label' => Yii::t('YupeModule.yupe', 'Modules'),
                 'url'   => array('/yupe/backend/settings'),
             ),
             array(
-                'icon'  => 'picture',
+                'icon'  => 'icon-picture',
                 'label' => Yii::t('YupeModule.yupe', 'Theme settings'),
                 'url'   => array('/yupe/backend/themesettings'),
             ),
             array(
-                'icon'  => 'wrench',
+                'icon'  => 'icon-wrench',
                 'label' => Yii::t('YupeModule.yupe', 'Site settings'),
                 'url'   => array(
                     '/yupe/backend/modulesettings',
@@ -537,7 +537,7 @@ class YupeModule extends WebModule
                 ),
             ),
             array(
-                'icon'  => "question-sign",
+                'icon'  => "icon-question-sign",
                 'label' => Yii::t('YupeModule.yupe', 'About Yupe!'),
                 'url'   => array('/yupe/backend/help'),
             )
@@ -611,7 +611,7 @@ class YupeModule extends WebModule
      **/
     public function getIcon()
     {
-        return "cog";
+        return "fa fa-fw fa-cog";
     }
 
     /**

--- a/protected/modules/yupe/components/ModuleManager.php
+++ b/protected/modules/yupe/components/ModuleManager.php
@@ -64,10 +64,10 @@ class ModuleManager extends \CApplicationComponent
         $this->otherCategoryName = Yii::t('YupeModule.yupe', 'Other');
 
         $this->categoryIcon = array(
-            Yii::t('YupeModule.yupe', 'Services') => 'briefcase',
-            Yii::t('YupeModule.yupe', 'Yupe!')    => 'cog',
-            Yii::t('YupeModule.yupe', 'Content')  => 'file',
-            $this->otherCategoryName => 'cog',
+            Yii::t('YupeModule.yupe', 'Services') => 'fa fa-fw fa-briefcase',
+            Yii::t('YupeModule.yupe', 'Yupe!')    => 'fa fa-fw fa-cog',
+            Yii::t('YupeModule.yupe', 'Content')  => 'fa fa-fw fa-file',
+            $this->otherCategoryName => 'fa fa-fw fa-cog',
         );
 
         $this->categorySort = array(

--- a/protected/modules/yupe/views/assets/css/frontpanel.css
+++ b/protected/modules/yupe/views/assets/css/frontpanel.css
@@ -18,6 +18,7 @@
 
 .navbar .nav > li > a {
     padding: 10px 8px;
+    color: #000000;
 }
 
 .navbar .brand img {
@@ -41,3 +42,6 @@
     width: 40px;
 }
 
+.nav-list .fa {
+    color: #000;
+}

--- a/protected/modules/yupe/views/backend/_moduleslist.php
+++ b/protected/modules/yupe/views/backend/_moduleslist.php
@@ -74,7 +74,7 @@ function moduleRow($module, &$updates, &$modules)
 {
 ?>
     <tr class="<?php echo ($module->getIsActive()) ? (is_array($module->checkSelf()) ? 'error' : '') : 'muted';?>">
-        <td><?php echo $module->icon ? "<i class='icon-" . $module->getIcon() . "'>&nbsp;</i> " : ""; ?></td>
+        <td><?php echo $module->icon ? "<i class='" . $module->getIcon() . "'>&nbsp;</i> " : ""; ?></td>
         <td>
             <small style="font-size: 80%;"><?php echo Yii::t('YupeModule.yupe', $module->getCategory()); ?></small><br />
             <?php if ($module->getIsActive() || $module->getIsNoDisable()): ?>

--- a/protected/modules/yupe/views/backend/index.php
+++ b/protected/modules/yupe/views/backend/index.php
@@ -28,7 +28,7 @@
                                 href="#collapse<?php echo $module->getId(); ?>"
                                 >
                                 <?php echo Yii::t('YupeModule.yupe', 'Module {icon} "{module}", messages: {count}', array(
-                                        '{icon}'   => $module->icon ? "<i class='icon-" . $module->icon . "'>&nbsp;</i> " : "",
+                                        '{icon}'   => $module->icon ? "<i class='" . $module->icon . "'>&nbsp;</i> " : "",
                                         '{module}' => $module->getName(),
                                         '{count}'  => '<small class="label label-warning">' . count($value) . '</small>',
                                     )); ?>

--- a/protected/modules/yupe/widgets/YShortCuts.php
+++ b/protected/modules/yupe/widgets/YShortCuts.php
@@ -32,20 +32,6 @@ class YShortCuts extends YWidget
     }
 
     /**
-     * Возвращаем иконки:
-     *
-     * @param string $icon - icon attribute
-     *
-     * @return string icons
-     **/
-    public function getIcons($icon)
-    {
-        return ($icons = explode(' ', $icon)) && count($icons) > 0
-            ? 'fa-'.implode(' fa-', explode(' ', $icon))
-            : '';
-    }
-
-    /**
      * Получаем htmlOptions:
      *
      * @param array $shortcut - массив эллемента
@@ -78,7 +64,7 @@ class YShortCuts extends YWidget
      **/
     public function getLabel($shortcut)
     {
-        return CHtml::tag('i', array('class' => "shortcut-icon fa " . $this->getIcons($shortcut['icon'])), '')
+        return CHtml::tag('i', array('class' => "shortcut-icon " . $shortcut['icon']), '')
              . CHtml::tag('span', array('class' => 'shortcut-label'), $shortcut['label']);
     }
 

--- a/protected/modules/yupe/widgets/views/moduleinfowidget.php
+++ b/protected/modules/yupe/widgets/views/moduleinfowidget.php
@@ -3,7 +3,7 @@
     <?php
     // @TODO: В случае, если это не бутстраповская иконка - выводить бекграундом
     if ($module->icon)
-        echo '<i class="icon-' . $module->icon. '"><!-- icon --></i>';
+        echo '<i class="' . $module->icon. '"><!-- icon --></i>';
     ?>
     <span class="label label-info" title="<?php echo Yii::t('YupeModule.yupe', 'version'); ?>"><?php echo $module->version; ?></span>
     <?php echo $module->name; ?>

--- a/protected/modules/zendsearch/ZendSearchModule.php
+++ b/protected/modules/zendsearch/ZendSearchModule.php
@@ -93,7 +93,7 @@ class ZendSearchModule extends yupe\components\WebModule
 
     public function getIcon()
     {
-        return "search";
+        return "fa fa-fw fa-search";
     }
 
     public function getAdminPageLink()
@@ -118,7 +118,7 @@ class ZendSearchModule extends yupe\components\WebModule
     {
         return array(
             array(
-                'icon' => 'list-alt',
+                'icon' => 'icon-list-alt',
                 'label' => Yii::t('ZendSearchModule.zendsearch', 'Index'),
                 'url' => array('/zendsearch/manageBackend/index')
             )


### PR DESCRIPTION
Поменял иконки модулей на полные имена классов из FA (потому что во 2 бутстрапе иконки картинками и не масштабируются, а в панели быстрого доступа иконки большие), для навигации модулей изменил классы бутсрапа на полные имена.
