### PR TITLE
Добавлено поведение для проверки на изменение атрибутов модели.

### DIFF
--- a/protected/modules/yupe/components/behaviors/YModelIsModifiedBehavior.php
+++ b/protected/modules/yupe/components/behaviors/YModelIsModifiedBehavior.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Class YModelIsModifiedBehavior
+ * Поведение для проверки изменения модели.
+ * Также через методы поведения можно получить список изменившихся атрибутов.
+ * Удобно использовать для того, чтобы сохранять в базу только изменившиеся модели.
+ *
+ * Стоит учитывать то, что если атрибут задан через CDbExpression, то он всегда будет считаться изменённым.
+ *
+ * @author Zalatov A.
+ *
+ * Атрибуты через геттеры/сеттеры:
+ * @property-read array		$oldAttributes			Массив с изначальными атрибутами
+ * @property-read bool		$isModified				Флаг, изменились ли атрибуты модели или нет
+ * @property-read array		$modifiedAttributes		Массив с изменёнными атрибутами
+ */
+class YModelIsModifiedBehavior extends CActiveRecordBehavior {
+	/**
+	 * Атрибуты, которые не надо учитывать при проверке изменения модели
+	 * Эти атрибуты можно задать в настройках при подключении поведения.
+	 */
+	public $exceptAttributes = array(
+		'id',
+		'insert_stamp',
+		'update_stamp',
+	);
+
+	/**
+	 * Массив с изначальными значениями атрибутов
+	 */
+	private $_oldAttributes = array();
+
+	/**
+	 * Действие при подключении behavior'а к модели
+	 *
+	 * @author Zalatov A.
+	 */
+	public function onAttachBehavior() {
+		// -- После поиска модели запоминаем значения атрибутов, чтобы потом с ними можно было бы что-нибудь сделать
+		$this->owner->attachEventHandler('onAfterFind', array($this, 'onAttachEventHandler'));
+		// -- -- -- --
+	}
+
+	/**
+	 * @param CEvent $event
+	 */
+	public function onAttachEventHandler($event) {
+		$event->sender->setOldAttributes($event->sender->attributes);
+	}
+
+	/**
+	 * Сеттер для установки значений изначальных атрибутов
+	 *
+	 * @author Zalatov A.
+	 */
+	public function setOldAttributes($attributes) {
+		$this->_oldAttributes = $attributes;
+	}
+
+	/**
+	 * Геттер для получения списка значений изначальных атрибутов
+	 *
+	 * @author Zalatov A.
+	 *
+	 * @return array
+	 */
+	public function getOldAttributes() {
+		return $this->_oldAttributes;
+	}
+
+	/**
+	 * Проверка, является ли модель изменённой (хотя бы один атрибут модели был изменён)
+	 *
+	 * Можно использовать по аналогии с isNewRecord, то есть это "геттер" метод - $this->isChanged вместо $this->getIsChanged()
+	 * Проходимся по всем атрибутам ДО и сравниваем с текущими атрибутами
+	 *
+	 * @author Zalatov A.
+	 *
+	 * @return bool
+	 */
+	public function getIsModified() {
+		if ($this->owner->isNewRecord) return true;// Новая модель всегда считается изменённой
+
+		$changed = $this->getModifiedAttributes();
+		return (count($changed) > 0);
+	}
+
+	/**
+	 * Получение массива с изменёнными атрибутами
+	 * Проходимся по всем атрибутам ДО и сравниваем с текущими атрибутами
+	 *
+	 * @author Zalatov A.
+	 *
+	 * @return array
+	 */
+	public function getModifiedAttributes() {
+		$result = array();
+
+		foreach ($this->owner->attributes as $attribute => $new_value) {
+			$old_value = null;
+			if (isset($this->_oldAttributes[$attribute])) $old_value = $this->_oldAttributes[$attribute];
+
+			if (in_array($attribute, $this->exceptAttributes)) continue;// Если атрибут является исключённым из проверки
+
+			if ($old_value == $new_value) continue;// Если значение не изменилось
+
+			$result[$attribute] = array(
+				'old' => $old_value,
+				'new' => $new_value,
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Сохранение только изменённых аттрибутов модели
+	 *
+	 * @author Zalatov A.
+	 *
+	 * @return bool
+	 * @throws CDbException В случае, если модели ещё нет в базе
+	 */
+	public function saveModifiedAttributes() {
+		if ($this->owner->getIsNewRecord()) {
+			throw new CDbException(Yii::t('yii', 'The active record cannot be updated because it is new.'));
+		}
+
+		$modified_attributes = $this->getModifiedAttributes();
+		if (count($modified_attributes) == 0) return true;// Если изменений нет, сразу возвращаем true
+		return $this->owner->update(array_keys($modified_attributes));
+	}
+}

--- a/protected/modules/yupe/models/YModel.php
+++ b/protected/modules/yupe/models/YModel.php
@@ -105,6 +105,26 @@ abstract class YModel extends CActiveRecord
         return (isset($descriptions[$attribute])) ? $descriptions[$attribute] : '';
     }
 
+	/**
+	 * Подключение внешних поведений (behavior).
+	 *
+	 * Этот метод переопределяет базовый метод Yii, чтобы при подключении вызывалось событие onAttachBehavior.
+	 * Перед вызовом проверяется, есть ли у behavior'а такой метод или нет.
+	 * Бывает необходимо, чтобы behavior инициализировал какие-нибудь данные сразу после подключения к модели.
+	 *
+	 * @author Zalatov A.
+	 *
+	 * @param array $behaviors Список behavior'ов, которые должны быть подключены
+	 */
+	public function attachBehaviors($behaviors) {
+		foreach($behaviors as $name => $behavior) {
+			$behavior_instance = $this->attachBehavior($name, $behavior);
+			if (method_exists($behavior_instance, 'onAttachBehavior')) {
+				$behavior_instance->onAttachBehavior();
+			}
+		}
+	}
+
     /**
      * Загружаем можель по её PK
      *


### PR DESCRIPTION
Поведение позволяет:
1. Узнать, какие были атрибуты ДО изменений.
2. Определить. изменилась ли модель или нет (изменились ли атрибуты).
3. Сохранить только изменившиеся атрибуты.

Удобно использовать, чтобы, например:
- Вести логи изменений;
- Не делать save/update тогда, когда он не нужен.

---

Behavior simple use for:
1. Get start attribute values (after find method)
2. Check. model is changed or not
3. Save only changed attributes

For example, you can do it in:
- Write modified logs;
- Do not save/update when it's not needed