### PR TITLE
Фикс добавления страницы в меню и определенеие активности обычных ссылок

### DIFF
--- a/protected/modules/menu/components/YMenu.php
+++ b/protected/modules/menu/components/YMenu.php
@@ -1,0 +1,10 @@
+<?php
+Yii::import('booster.widgets.TbMenu');
+
+class YMenu extends TbMenu
+{
+    public function isItemActive($item, $route)
+    {
+        return parent::isItemActive($item, $route) || (isset($item['url']) && is_string($item['url']) ? strcasecmp($item['url'], Yii::app()->getRequest()->requestUri) == 0 : false);
+    }
+}

--- a/protected/modules/page/controllers/PageBackendController.php
+++ b/protected/modules/page/controllers/PageBackendController.php
@@ -67,32 +67,25 @@ class PageBackendController extends yupe\components\controllers\BackController
     public function actionCreate()
     {
         $model = new Page();
-
         $menuId = null;
         $menuParentId = 0;
 
         if (($data = Yii::app()->getRequest()->getPost('Page')) !== null) {
-
             $model->setAttributes($data);
-
             $transaction = Yii::app()->db->beginTransaction();
-
             try {
-
                 if ($model->save()) {
-
                     // если активен модуль "Меню" - сохраним в меню
                     if (Yii::app()->hasModule('menu')) {
-
                         $menuId = (int)Yii::app()->getRequest()->getPost('menu_id');
                         $parentId = (int)Yii::app()->getRequest()->getPost('parent_id');
-
-                        $menu = Menu::model()->active()->findByPk($menuId);
+                        $menu = Menu::model()->findByPk($menuId);
                         if ($menu) {
                             if (!$menu->addItem(
                                 $model->title,
-                                serialize(array('/page/page/show', 'slug' => $model->slug)),
-                                $parentId
+                                $model->getUrl(),
+                                $parentId,
+                                true
                             )
                             ) {
                                 throw new CDbException(
@@ -212,13 +205,14 @@ class PageBackendController extends yupe\components\controllers\BackController
 
                     $menuId = (int)Yii::app()->getRequest()->getPost('menu_id');
                     $parentId = (int)Yii::app()->getRequest()->getPost('parent_id');
-                    $menu = Menu::model()->active()->findByPk($menuId);
+                    $menu = Menu::model()->findByPk($menuId);
                     if ($menu) {
                         if (!$menu->changeItem(
                             $oldTitle,
                             $model->title,
-                            serialize(array('/page/page/show', 'slug' => $model->slug)),
-                            $parentId
+                            $model->getUrl(),
+                            $parentId,
+                            true
                         )
                         ) {
                             throw new CDbException(

--- a/protected/modules/page/controllers/PageController.php
+++ b/protected/modules/page/controllers/PageController.php
@@ -88,7 +88,7 @@ class PageController extends yupe\components\controllers\FrontController
     private function getBreadCrumbsRecursively(Page $page)
     {
         $pages = array();
-        $pages[$page->title] = array('/page/page/show', 'slug' => $page->slug);
+        $pages[$page->title] = $page->getUrl();
         $pp = $page->parentPage;
         if ($pp) {
             $pages += $this->getBreadCrumbsRecursively($pp);

--- a/protected/modules/page/models/Page.php
+++ b/protected/modules/page/models/Page.php
@@ -157,31 +157,31 @@ class Page extends yupe\models\YModel
             'creation_date'  => Yii::t('PageModule.page', 'Created at'),
             'change_date'    => Yii::t('PageModule.page', 'Updated at'),
             'title'          => Yii::t(
-                    'PageModule.page',
-                    'Full page title which will be displayed in page header.<br/><br />For example:<pre>Contact information and road map.</pre>'
-                ),
+                'PageModule.page',
+                'Full page title which will be displayed in page header.<br/><br />For example:<pre>Contact information and road map.</pre>'
+            ),
             'title_short'    => Yii::t(
-                    'PageModule.page',
-                    'Short page title which wil be displayed in widgets and menus<br/><br />For example:<pre>Contacts</pre>'
-                ),
+                'PageModule.page',
+                'Short page title which wil be displayed in widgets and menus<br/><br />For example:<pre>Contacts</pre>'
+            ),
             'slug'           => Yii::t(
-                    'PageModule.page',
-                    'Short page title for URL generation<br /><br /> For example: <pre>http://site.ru/page/<span class=\'label\'>contacts</span>/</pre> You can leave it empty for automatic generation.'
-                ),
+                'PageModule.page',
+                'Short page title for URL generation<br /><br /> For example: <pre>http://site.ru/page/<span class=\'label\'>contacts</span>/</pre> You can leave it empty for automatic generation.'
+            ),
             'lang'           => Yii::t('PageModule.page', 'Page language'),
             'body'           => Yii::t('PageModule.page', 'Page text'),
             'keywords'       => Yii::t(
-                    'PageModule.page',
-                    'Keywords for SEO optimization. Insert a few words which have sense in article context. For example: <pre>address, road map, contacts.</pre>'
-                ),
+                'PageModule.page',
+                'Keywords for SEO optimization. Insert a few words which have sense in article context. For example: <pre>address, road map, contacts.</pre>'
+            ),
             'description'    => Yii::t(
-                    'PageModule.page',
-                    'Short page description. About one or two sentences. Usually this is the main idea. For example: <pre>Contact information about my company</pre>This text very frequently falls in <a href="http://help.yandex.ru/webmaster/?id=111131">snippet</a>of search engines.'
-                ),
+                'PageModule.page',
+                'Short page description. About one or two sentences. Usually this is the main idea. For example: <pre>Contact information about my company</pre>This text very frequently falls in <a href="http://help.yandex.ru/webmaster/?id=111131">snippet</a>of search engines.'
+            ),
             'status'         => Yii::t(
-                    'PageModule.page',
-                    '<span class=\'label label-success\'>Published</span> &ndash; Page is visible for all users by default.<br /><br /><span class=\'label label-default\'>Draft</span> &ndash; Page will be invisible for users.<br /><br /><span class=\'label label-info\'>On moderation</span> &ndash; Page is not checked and it will be invisible for users.'
-                ),
+                'PageModule.page',
+                '<span class=\'label label-success\'>Published</span> &ndash; Page is visible for all users by default.<br /><br /><span class=\'label label-default\'>Draft</span> &ndash; Page will be invisible for users.<br /><br /><span class=\'label label-info\'>On moderation</span> &ndash; Page is not checked and it will be invisible for users.'
+            ),
             'is_protected'   => Yii::t('PageModule.page', 'Access: * Only for authorized members'),
             'user_id'        => Yii::t('PageModule.page', 'Page creator'),
             'change_user_id' => Yii::t('PageModule.page', 'Page editor'),
@@ -266,10 +266,12 @@ class Page extends yupe\models\YModel
         $criteria->compare('is_protected', $this->is_protected);
         $criteria->compare('layout', $this->layout);
 
-        return new CActiveDataProvider(get_class($this), array(
-            'criteria' => $criteria,
-            'sort'     => array('defaultOrder' => 't.order DESC, t.creation_date DESC'),
-        ));
+        return new CActiveDataProvider(
+            get_class($this), array(
+                'criteria' => $criteria,
+                'sort'     => array('defaultOrder' => 't.order DESC, t.creation_date DESC'),
+            )
+        );
     }
 
     public function getStatusList()
@@ -341,13 +343,17 @@ class Page extends yupe\models\YModel
         return ($this->parentPage === null) ? '---' : $this->parentPage->title;
     }
 
-    public function getPermaLink()
-    {
-        return Yii::app()->createAbsoluteUrl('/page/page/show/', array('slug' => $this->slug));
-    }
-
     public function isProtected()
     {
         return $this->is_protected == self::PROTECTED_YES;
+    }
+
+    /**
+     * @param bool $absolute
+     * @return string
+     */
+    public function getUrl($absolute = false)
+    {
+        return $absolute ? Yii::app()->createAbsoluteUrl('/page/page/show/', array('slug' => $this->slug)) : Yii::app()->createUrl('/page/page/show/', array('slug' => $this->slug));
     }
 }

--- a/protected/modules/page/views/pageBackend/view.php
+++ b/protected/modules/page/views/pageBackend/view.php
@@ -68,7 +68,4 @@ $this->menu = array(
 <br/>
 
 <li class="glyphicon glyphicon-globe"></li>
-<?php echo CHtml::link(
-    Yii::app()->createAbsoluteUrl("/page/page/show", array("slug" => $model->slug)),
-    array('/page/page/show', 'slug' => $model->slug)
-); ?>
+<?php echo CHtml::link($model->getUrl(true), $model->getUrl()); ?>

--- a/themes/default/views/menu/widgets/MenuWidget/main.php
+++ b/themes/default/views/menu/widgets/MenuWidget/main.php
@@ -1,4 +1,5 @@
 <?php
+Yii::import('application.modules.menu.components.YMenu');
 $this->widget(
     'bootstrap.widgets.TbNavbar',
     array(
@@ -15,7 +16,7 @@ $this->widget(
         'brandUrl' => '/',
         'items'    => array(
             array(
-                'class' => 'bootstrap.widgets.TbMenu',
+                'class' => 'YMenu',
                 'type'  => 'navbar',
                 'items' => $this->params['items'],
             ),


### PR DESCRIPTION
Страницы при выборе меню сохраняются как обычные ссылки с уже сформированным url, например, если ничего не менять в настройках модуля page, то добавятся с адресом /pages/test. 
Сохраняются как обычные ссылки, потому что это явно логичней для пользователя, чем ссылки вида /page/page/show?slug=test.
Для подсвечивания активного пункта меню для обычных ссылок используется немного переопределенный TbMenu (menu/components/YMenu), который сравнивает запрошенный url с url в пункте меню, и если они соответствуют, то он становится активным.
