### PR TITLE
Добавлена команда в composer.json для копирования install.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,9 @@
     "scripts": {
         "post-create-project-cmd": [
             "php -r \"copy('protected/modules/install/install/install.php', 'protected/config/modules/install.php');\""
+        ],
+        "post-install-cmd": [
+            "php -r \"copy('protected/modules/install/install/install.php', 'protected/config/modules/install.php');\""
         ]
     }
 }


### PR DESCRIPTION
Решает https://github.com/yupe/yupe/issues/1622

Нужно ли дублировать эту команду для post-install?
