### PR TITLE
Правила маршрутизации из модулей добавляются перед системными

### DIFF
--- a/protected/modules/yupe/components/ConfigManager.php
+++ b/protected/modules/yupe/components/ConfigManager.php
@@ -342,8 +342,8 @@ class ConfigManager extends CComponent
         if (isset($this->_config['components']['urlManager']['rules'])) {
             // Фикс для настроек маршрутизации:
             $this->_config['components']['urlManager']['rules'] = CMap::mergeArray(
-                $this->_config['components']['urlManager']['rules'],
-                $settings['rules']
+                $settings['rules'],
+                $this->_config['components']['urlManager']['rules']
             );
         }
 


### PR DESCRIPTION
Чтобы была возможно переопределить стандартные правила через другие модули и project.php
