### PR TITLE
Модуль: Блоки контента - мелкие правки

### DIFF
--- a/protected/modules/contentblock/views/contentBlockBackend/index.php
+++ b/protected/modules/contentblock/views/contentBlockBackend/index.php
@@ -109,25 +109,9 @@ $this->menu = [
                 'filter'   => CHtml::activeTextField($model, 'code', ['class' => 'form-control']),
             ],
             [
-                'class'    => 'bootstrap.widgets.TbEditableColumn',
-                'name'     => 'description',
-                'editable' => [
-                    'url'       => $this->createUrl('/contentblock/contentBlockBackend/inline'),
-                    'title'     => Yii::t(
-                            'ContentBlockModule.contentblock',
-                            'Select {field}',
-                            ['{field}' => mb_strtolower($model->getAttributeLabel('description'))]
-                        ),
-                    'emptytext' => Yii::t(
-                            'ContentBlockModule.contentblock',
-                            'Select {field}',
-                            ['{field}' => mb_strtolower($model->getAttributeLabel('description'))]
-                        ),
-                    'params'    => [
-                        Yii::app()->getRequest()->csrfTokenName => Yii::app()->getRequest()->csrfToken
-                    ]
-                ],
-                'filter'   => CHtml::activeTextField($model, 'description', ['class' => 'form-control']),
+                'name' => 'description',
+                'type' => 'raw',
+                'value' => '$data->description',
             ],
             [
                 'class' => 'yupe\widgets\CustomButtonColumn',

--- a/protected/modules/contentblock/views/contentBlockBackend/update.php
+++ b/protected/modules/contentblock/views/contentBlockBackend/update.php
@@ -46,7 +46,7 @@ $this->menu = [
     ],
     [
         'icon'        => 'fa fa-fw fa-trash-o',
-        'label'       => Yii::t('ContentBlockModule.contentblock', 'Remove Content block'),
+        'label'       => Yii::t('ContentBlockModule.contentblock', 'Remove content block'),
         'url'         => '#',
         'linkOptions' => [
             'submit'  => ['/contentblock/contentBlockBackend/delete', 'id' => $model->id],

--- a/protected/modules/contentblock/views/contentBlockBackend/view.php
+++ b/protected/modules/contentblock/views/contentBlockBackend/view.php
@@ -76,7 +76,11 @@ $this->menu = [
                 'value' => $model->getType(),
             ],
             'content',
-            'description',
+            [
+                'name' => 'description',
+                'type' => 'raw',
+                'value' => $model->description,
+            ]
         ],
     ]
 ); ?>


### PR DESCRIPTION
- на странице редактирования блока контента исправлен titile ссылки "Удалить контент блок"
- так как в описании в блоку вводиться html текст, то исправлено отображение описания при выводе списка блоков и на странице просмотра отдельного блока