### PR TITLE
Откат #1876

### DIFF
--- a/protected/modules/menu/models/Menu.php
+++ b/protected/modules/menu/models/Menu.php
@@ -224,7 +224,7 @@ class Menu extends yupe\models\YModel
                         $url = ['url' => (array)$url + $param, 'items' => $childItems];
                     } else {
                         // если обычная ссылка
-                        $url = ['url' => ($result->href === '/' ? Yii::app()->getHomeUrl() : trim($result->href, '/')), 'items' => $childItems];
+                        $url = ['url' => $result->href, 'items' => $childItems];
                     }
                 } elseif ($childItems) {
                     $url = ['url' => ['#'], 'items' => $childItems];

--- a/protected/modules/yupe/components/urlManager/LangUrlManager.php
+++ b/protected/modules/yupe/components/urlManager/LangUrlManager.php
@@ -114,7 +114,7 @@ class LangUrlManager extends CUrlManager
                 unset($params[$this->langParam]);
             } else {
                 if (trim($route, '/') == "") {;
-                    return '/' . $params[$this->langParam];
+                    return Yii::app()->getHomeUrl() . $params[$this->langParam];
                 }
             }
         }

--- a/protected/modules/yupe/components/urlManager/LangUrlManager.php
+++ b/protected/modules/yupe/components/urlManager/LangUrlManager.php
@@ -114,7 +114,7 @@ class LangUrlManager extends CUrlManager
                 unset($params[$this->langParam]);
             } else {
                 if (trim($route, '/') == "") {;
-                    return Yii::app()->getHomeUrl() . $params[$this->langParam];
+                    return '/' . $params[$this->langParam];
                 }
             }
         }

--- a/themes/default/views/layouts/main.php
+++ b/themes/default/views/layouts/main.php
@@ -30,7 +30,6 @@
     <![endif]-->
     <link rel="stylesheet" href="http://yandex.st/highlightjs/8.2/styles/github.min.css">
     <script src="http://yastatic.net/highlightjs/8.2/highlight.min.js"></script>
-    <base href="<?= Yii::app()->getBaseUrl(true) . '/' ?>">
 </head>
 
 <body>


### PR DESCRIPTION
Слишком много магии при работе с обычными ссылками, для работы системы во вложенной папке адреса в меню должны быть просто соответствующими.
Например, если юпи установлена в http://localhost/yupe/public, то пункт меню для обычной ссылки test.html в корне сайта должен быть не /test.html, а /yupe/public/test.html