### PR TITLE
Модуль "Comment". Параметры, фикс багов, редактор, text + CHtmlPurifier

### DIFF
--- a/protected/modules/comment/CommentModule.php
+++ b/protected/modules/comment/CommentModule.php
@@ -28,6 +28,13 @@ class CommentModule extends WebModule
     public $antiSpamInterval = 3;
     public $allowedTags;
     public $allowGuestComment = 0;
+    public $stripTags = 1;
+    public $assetsPath = "application.modules.comment.views.assets";
+
+    /**
+    * @var string - id редактора
+    */
+    public $editor = 'textarea';
 
     public function getDependencies()
     {
@@ -50,7 +57,9 @@ class CommentModule extends WebModule
             'rssCount'             => Yii::t('CommentModule.comment', 'RSS records count'),
             'allowedTags'          => Yii::t('CommentModule.comment', 'Accepted tags'),
             'antiSpamInterval'     => Yii::t('CommentModule.comment', 'Antispam interval'),
-            'allowGuestComment'    => Yii::t('CommentModule.comment', 'Guest can comment ?')
+            'allowGuestComment'    => Yii::t('CommentModule.comment', 'Guest can comment ?'),
+            'editor'               => Yii::t('YupeModule.yupe', 'Visual editor'),
+            'stripTags'            => Yii::t('CommentModule.comment', 'Remove tags in the derivation comment using strip_tags() ?'),
         ];
     }
 
@@ -68,7 +77,9 @@ class CommentModule extends WebModule
             'maxCaptchaLength',
             'rssCount',
             'allowedTags',
-            'antiSpamInterval'
+            'antiSpamInterval',
+            'stripTags' => $this->getChoice(),
+            'editor' => $this->editors,
         ];
     }
 
@@ -91,6 +102,12 @@ class CommentModule extends WebModule
                     'showCaptcha',
                     'minCaptchaLength',
                     'maxCaptchaLength'
+                ]
+            ],
+            'editor' => [
+                'label' => Yii::t('YupeModule.yupe', 'Visual editors settings'),
+                'items' => [
+                    'editor',
                 ]
             ],
         ];

--- a/protected/modules/comment/components/ICommentAllowed.php
+++ b/protected/modules/comment/components/ICommentAllowed.php
@@ -1,0 +1,6 @@
+<?php
+
+interface ICommentAllowed
+{
+    public function isCommentAllowed();
+}

--- a/protected/modules/comment/install/comment.php
+++ b/protected/modules/comment/install/comment.php
@@ -17,6 +17,14 @@ return [
                 'limit' => 5
             ]
         ],
+        'visualEditors' => [
+            'redactor' => [
+                'class' => 'yupe\widgets\editors\Redactor',
+            ],
+            'textarea' => [
+                'class' => 'yupe\widgets\editors\Textarea',
+            ],
+        ],
     ],
     'import'    => [
         'application.modules.comment.models.*',

--- a/protected/modules/comment/messages/en/comment.php
+++ b/protected/modules/comment/messages/en/comment.php
@@ -108,4 +108,12 @@ return [
     'WRITE COMMENT'                                               => '',
     'From user'                                                   => '',
     'Insert symbols you see on picture'                           => '',
+    'Creating comment'                                            => '',
+    'Removing comment'                                            => '',
+    'List of comments'                                            => '',
+    'Editing comment'                                             => '',
+    'Viewing comments'                                            => '',
+    'Batch delete'                                                => '',
+    'Remove tags in the derivation comment using strip_tags() ?'  => '',
+    'Not have permission to add a comment!'                       => ''
 ];

--- a/protected/modules/comment/messages/ru/comment.php
+++ b/protected/modules/comment/messages/ru/comment.php
@@ -119,11 +119,12 @@ return [
     'WRITE COMMENT'                                               => ' НАПИСАТЬ КОММЕНТАРИЙ',
     'From user'                                                   => 'От имени',
     'Insert symbols you see on picture'                           => 'Введите цифры указанные на картинке',
-    'Manage comments'                                             => 'Управление комментариями',
     'Creating comment'                                            => 'Создание комментария',
     'Removing comment'                                            => 'Удаление комментария',
     'List of comments'                                            => 'Просмотр списка комментариев',
     'Editing comment'                                             => 'Редактирование комментария',
     'Viewing comments'                                            => 'Просмотр комментариев',
     'Batch delete'                                                => 'Массовое удаление комментариев',
+    'Remove tags in the derivation comment using strip_tags() ?'  => 'Удалять теги при выводе комментария, используя strip_tags() ?',
+    'Not have permission to add a comment!'                       => 'Недостаточно прав для добавления комментария!'
 ];

--- a/protected/modules/comment/messages/zh_cn/comment.php
+++ b/protected/modules/comment/messages/zh_cn/comment.php
@@ -108,4 +108,12 @@ return [
     'WRITE COMMENT'                                               => '',
     'From user'                                                   => '',
     'Insert symbols you see on picture'                           => '',
+    'Creating comment'                                            => '',
+    'Removing comment'                                            => '',
+    'List of comments'                                            => '',
+    'Editing comment'                                             => '',
+    'Viewing comments'                                            => '',
+    'Batch delete'                                                => '',
+    'Remove tags in the derivation comment using strip_tags() ?'  => '',
+    'Not have permission to add a comment!'                       => ''
 ];

--- a/protected/modules/comment/models/Comment.php
+++ b/protected/modules/comment/models/Comment.php
@@ -226,6 +226,13 @@ class Comment extends yupe\models\YModel
             $this->ip = Yii::app()->getRequest()->userHostAddress;
         }
 
+        $module = Yii::app()->getModule('comment');
+        $p = new CHtmlPurifier;
+        $p->options = [
+            'HTML.Allowed' => $module->allowedTags,
+        ];
+        $this->text = $p->purify($this->text);
+
         return parent::beforeSave();
     }
 
@@ -323,7 +330,9 @@ class Comment extends yupe\models\YModel
 
     public function getText()
     {
-        return strip_tags($this->text, Yii::app()->getModule('comment')->allowedTags);
+        return ( Yii::app()->getModule('comment')->stripTags )
+            ? strip_tags($this->text)
+            : $this->text;
     }
 
     /**

--- a/protected/modules/comment/models/Comment.php
+++ b/protected/modules/comment/models/Comment.php
@@ -83,7 +83,8 @@ class Comment extends yupe\models\YModel
 
         return [
             ['model, name, email, text, url', 'filter', 'filter' => 'trim'],
-            ['model, name, email, text, url', 'filter', 'filter' => [$obj = new CHtmlPurifier(), 'purify']],
+            ['model, name, email, url', 'filter', 'filter' => [$obj = new CHtmlPurifier(), 'purify']],
+            ['text', 'purifyText'],
             ['model, model_id, name, email, text', 'required'],
             ['status, user_id, model_id, parent_id', 'numerical', 'integerOnly' => true],
             ['name, email, url, comment', 'length', 'max' => 150],
@@ -108,6 +109,16 @@ class Comment extends yupe\models\YModel
                 'on' => 'search'
             ],
         ];
+    }
+
+    public function purifyText($attribute, $params)
+    {
+        $module = Yii::app()->getModule('comment');
+        $p = new CHtmlPurifier();
+        $p->options = [
+            'HTML.Allowed' => $module->allowedTags,
+        ];
+        $this->$attribute = $p->purify($this->$attribute);
     }
 
     /**
@@ -225,13 +236,6 @@ class Comment extends yupe\models\YModel
             $this->creation_date = new CDbExpression('NOW()');
             $this->ip = Yii::app()->getRequest()->userHostAddress;
         }
-
-        $module = Yii::app()->getModule('comment');
-        $p = new CHtmlPurifier;
-        $p->options = [
-            'HTML.Allowed' => $module->allowedTags,
-        ];
-        $this->text = $p->purify($this->text);
 
         return parent::beforeSave();
     }

--- a/protected/modules/comment/views/assets/js/comments.js
+++ b/protected/modules/comment/views/assets/js/comments.js
@@ -48,6 +48,7 @@ $(document).ready(function () {
             }
             if(response.result) {
                 $('#Comment_text').val('');
+                $('div.redactor-editor').html('');
             }
 
             $('#captcha-refresh').trigger('click');

--- a/protected/modules/comment/views/commentBackend/_form.php
+++ b/protected/modules/comment/views/commentBackend/_form.php
@@ -43,7 +43,7 @@ $form = $this->beginWidget(
     </div>
 </div>
 <div class='row'>
-    <div class="col-sm-7">
+    <div class="col-sm-12">
         <?php echo $form->labelEx($model, 'text'); ?>
         <?php $this->widget(
             $this->module->getVisualEditor(),

--- a/protected/modules/comment/views/commentBackend/index.php
+++ b/protected/modules/comment/views/commentBackend/index.php
@@ -67,7 +67,7 @@ $this->menu = [
             'model_id',
             [
                 'name'  => 'text',
-                'value' => 'yupe\helpers\YText::characterLimiter($data->text, 150)',
+                'value' => 'yupe\helpers\YText::characterLimiter($data->getText(), 150)',
                 'type'  => 'html'
             ],
             [

--- a/protected/modules/yupe/YupeModule.php
+++ b/protected/modules/yupe/YupeModule.php
@@ -129,12 +129,6 @@ class YupeModule extends WebModule
      */
     protected $backEndFilters = [['yupe\filters\YBackAccessControl - error']];
 
-    public $visualEditors = [
-        'redactor' => [
-            'class' => 'yupe\widgets\editors\RedactorEditor',
-        ],
-    ];
-
     /**
      * @return array
      * @since 0.8
@@ -663,17 +657,6 @@ class YupeModule extends WebModule
         } else {
             return 'application.modules.yupe.views.layouts.' . ($layoutName ? $layoutName : $this->backendLayout);
         }
-    }
-
-    /**
-     * Метод возвращает список доступных для использования в панели управления визуальных редакторов
-     *
-     * @since 0.4
-     * @return array
-     */
-    public function getEditors()
-    {
-        return array_combine(array_keys($this->visualEditors), array_keys($this->visualEditors));
     }
 
     /**

--- a/protected/modules/yupe/components/WebModule.php
+++ b/protected/modules/yupe/components/WebModule.php
@@ -84,6 +84,14 @@ abstract class WebModule extends CWebModule
     private $visualEditor = null;
 
     /**
+     * @var array - массив редакторов
+     */
+    public $visualEditors = [
+        'redactor' => [
+            'class' => 'yupe\widgets\editors\RedactorEditor',
+        ],
+    ];
+    /**
      * @var bool | string
      *
      * Имя модели, которая является профилем пользователя для конкретного модуля
@@ -1147,5 +1155,16 @@ abstract class WebModule extends CWebModule
             $this->visualEditor = $yupe->visualEditors[$editor]['class'];
         }
         return $this->visualEditor;
+    }
+
+    /**
+     * Метод возвращает список доступных для использования в панели управления визуальных редакторов
+     *
+     * @since 0.4
+     * @return array
+     */
+    public function getEditors()
+    {
+        return array_combine(array_keys($this->visualEditors), array_keys($this->visualEditors));
     }
 }

--- a/themes/default/views/comment/widgets/CommentFormWidget/commentformwidget.php
+++ b/themes/default/views/comment/widgets/CommentFormWidget/commentformwidget.php
@@ -1,3 +1,14 @@
+<?php
+Yii::app()->clientScript->registerScriptFile(Yii::app()->getModule('comment')->getAssetsUrl().'/js/comments.js');
+Yii::app()->clientScript->registerScript(
+    'spam-field',
+    "$(document).ready(function(){
+        $(document).on('focus', '#Comment_text, div.redactor-editor', function(){
+            $('#$spamField').val('$spamFieldValue');
+        })
+    });"
+); ?>
+
 <a href='#' id='wcml' style="display: none;"><?php echo Yii::t("CommentModule.comment", 'WRITE COMMENT'); ?></a>
 
 <div id='comment-form-wrap' class='comment-form-wrap'>
@@ -16,7 +27,6 @@
             ]
         ]
     ); ?>
-
 
     <?php echo $form->errorSummary($model); ?>
 
@@ -56,7 +66,19 @@
 
     <div class='row'>
         <div class="col-sm-12">
-            <?php echo $form->textAreaGroup($model, 'text'); ?>
+            <div class="form-group">
+                <?php echo $form->labelEx($model, 'text')?>
+                <?php $this->widget(
+                    $module->getVisualEditor(),
+                    [
+                        'model' => $model,
+                        'attribute' => 'text',
+                        'options' => [
+                            'rows' => '3',
+                        ]
+                    ]
+                ); ?>
+            </div>
         </div>
     </div>
 
@@ -114,13 +136,3 @@
     </div>
     <?php $this->endWidget(); ?>
 </div>
-
-<script type="text/javascript">
-    $(document).ready(function(){
-        $(document).on('focus', '#Comment_text', function(){
-           $('#<?= $spamField; ?>').val('<?= $spamFieldValue; ?>');
-        })
-    });
-</script>
-
-

--- a/themes/default/views/layouts/main.php
+++ b/themes/default/views/layouts/main.php
@@ -18,7 +18,6 @@
     Yii::app()->getClientScript()->registerScriptFile($mainAssets . '/js/blog.js');
     Yii::app()->getClientScript()->registerScriptFile($mainAssets . '/js/bootstrap-notify.js');
     Yii::app()->getClientScript()->registerScriptFile($mainAssets . '/js/jquery.li-translit.js');
-    Yii::app()->getClientScript()->registerScriptFile($mainAssets . '/js/comments.js');
     ?>
     <script type="text/javascript">
         var yupeTokenName = '<?php echo Yii::app()->getRequest()->csrfTokenName;?>';


### PR DESCRIPTION
Модуль "Comment". Настройка визуального редактора. Фикс багов. Корректное сохранение text

1) добавлен интерфейс ICommentAllowed.
2) в CommentManager добавлена проверка на наличие интерфейса ICommentAllowed и на разрешение добавления комментариев для этой модели
3) в CommentManager. CDbException заменен на CException
4) в файл конфига добавлен параметр visualEditors (список доступных редакторов)
5) добавлены тексты в папку messages
6) модель Comment. Перед сохранением text прогоняем через CHtmlPurifier и оставляем только разрешенные теги
7) модель Comment. В getText() учитывается параметр
8) comments.js перенесен из папки темы в папку модуля. Так же добавлен код очистки поля комментария с редактором Redactor
9) views/commentBackend/_form увеличина ширина текстового блока
10) views/commentBackend/index для вывода текста используется метод getText()
11) CommentModule. Добавлены параметры $stripTags и $editor, а так же путь к новому расположениею comments.js. Параметры вынесены в настройки и добавлены labels для них
12) $visualEditors, getEditors() перенесены из YupeModule в WebModule
13) commentformwidget. Задействованы Yii::app()->clientScript->registerScript для вывода и подключения js кода. Вместо textArea используется виджет для вывода поля text
13) из layouts/main убран вызов comments.js