### PR TITLE
Cвязи между товарами

### DIFF
--- a/protected/modules/store/StoreModule.php
+++ b/protected/modules/store/StoreModule.php
@@ -113,6 +113,11 @@ class StoreModule extends WebModule
                                 'label' => Yii::t('StoreModule.product', 'Create product'),
                                 'url' => ['/store/productBackend/create']
                             ],
+                            [
+                                'icon' => 'fa fa-fw fa-link',
+                                'label' => Yii::t('StoreModule.product', 'Link types'),
+                                'url' => ['/store/linkBackend/typeIndex']
+                            ],
                         ],
                     ],
                     [

--- a/protected/modules/store/controllers/LinkBackendController.php
+++ b/protected/modules/store/controllers/LinkBackendController.php
@@ -1,0 +1,116 @@
+<?php
+
+class LinkBackendController extends yupe\components\controllers\BackController
+{
+    public function accessRules()
+    {
+        return [
+            ['allow', 'roles' => ['admin']],
+            ['allow', 'actions' => ['delete', 'index', 'link', 'inline', 'typeIndex', 'typeCreate', 'typeDelete', 'typeInline'], 'roles' => ['Store.ProductBackend.Update']],
+            ['deny'],
+        ];
+    }
+
+    public function actions()
+    {
+        return [
+            'inline' => [
+                'class' => 'yupe\components\actions\YInLineEditAction',
+                'model' => 'ProductLink',
+                'validAttributes' => ['type_id']
+            ],
+            'typeInline' => [
+                'class' => 'yupe\components\actions\YInLineEditAction',
+                'model' => 'ProductLinkType',
+                'validAttributes' => ['code', 'title']
+            ],
+        ];
+    }
+
+    public function actionIndex()
+    {
+        $model = new ProductSearch('search');
+        $model->unsetAttributes();
+        $model->attributes = Yii::app()->getRequest()->getParam('ProductSearch');
+        $this->render('/productBackend/_link_form', ['searchModel' => $model]);
+    }
+
+    public function actionDelete($id)
+    {
+        if (Yii::app()->getRequest()->getIsPostRequest()) {
+            $this->loadModel($id)->delete();
+        } else {
+            throw new CHttpException(400, Yii::t('StoreModule.store', 'Unknown request. Don\'t repeat it please!'));
+        }
+    }
+
+    public function actionLink()
+    {
+        $r = Yii::app()->getRequest();
+        if ($r->isPostRequest) {
+            $product_id = $r->getParam('product_id');
+            $linked_product_id = $r->getParam('linked_product_id');
+            $type_id = $r->getParam('type_id');
+
+            $product = Product::model()->findByPk($product_id);
+            $linkedProduct = Product::model()->findByPk($linked_product_id);
+            if ($product && $linkedProduct && $product->id != $linkedProduct->id) {
+                Yii::app()->ajax->raw(['result' => $product->link($linkedProduct, $type_id)]);
+            }
+        }
+    }
+
+    public function actionTypeIndex()
+    {
+        $model = new ProductLinkType('search');
+        $model->unsetAttributes();
+        $model->attributes = Yii::app()->getRequest()->getParam('ProductLinkType');
+        $this->render('index_type', ['model' => $model]);
+    }
+
+    public function actionTypeCreate()
+    {
+        $model = new ProductLinkType();
+        if (($data = Yii::app()->getRequest()->getPost('ProductLinkType')) !== null) {
+            $model->setAttributes($data);
+            if ($model->save()) {
+
+                Yii::app()->user->setFlash(
+                    yupe\widgets\YFlashMessages::SUCCESS_MESSAGE,
+                    Yii::t('StoreModule.product', 'Record was added!')
+                );
+
+                $this->redirect((array)Yii::app()->getRequest()->getPost('submit-type', ['typeIndex']));
+            }
+        }
+        $this->render('index_type', ['model' => $model]);
+    }
+
+    public function actionTypeDelete($id)
+    {
+        if (Yii::app()->getRequest()->getIsPostRequest()) {
+            $model = ProductLinkType::model()->findByPk($id);
+            if ($model) {
+                $model->delete();
+            }
+        } else {
+            throw new CHttpException(400, Yii::t('StoreModule.store', 'Unknown request. Don\'t repeat it please!'));
+        }
+    }
+
+    /**
+     * @param $id
+     * @return ProductLink
+     * @throws CHttpException
+     */
+    public function loadModel($id)
+    {
+        $model = ProductLink::model()->findByPk($id);
+        if ($model === null) {
+            throw new CHttpException(404, Yii::t('StoreModule.store', 'Page was not found!'));
+        }
+
+        return $model;
+    }
+
+}

--- a/protected/modules/store/install/migrations/m150417_180000_store_product_link_base.php
+++ b/protected/modules/store/install/migrations/m150417_180000_store_product_link_base.php
@@ -1,0 +1,46 @@
+<?php
+
+class m150417_180000_store_product_link_base extends yupe\components\DbMigration
+{
+    public function safeUp()
+    {
+        $this->createTable(
+            '{{store_product_link_type}}',
+            [
+                'id' => 'pk',
+                'code' => 'string not null',
+                'title' => 'string not null',
+            ],
+            $this->getOptions()
+        );
+
+        $this->createIndex('ux_{{store_product_link_type}}_code', '{{store_product_link_type}}', 'code', true);
+        $this->createIndex('ux_{{store_product_link_type}}_title', '{{store_product_link_type}}', 'title', true);
+
+        $this->insert('{{store_product_link_type}}', ['code' => 'similar', 'title' => 'Похожие']);
+        $this->insert('{{store_product_link_type}}', ['code' => 'related', 'title' => 'Сопутствующие']);
+
+        $this->createTable(
+            '{{store_product_link}}',
+            [
+                'id' => 'pk',
+                'type_id' => 'int null',
+                'product_id' => 'int not null',
+                'linked_product_id' => 'int not null',
+            ],
+            $this->getOptions()
+        );
+
+        $this->createIndex('ux_{{store_product_link}}_product', '{{store_product_link}}', ['product_id', 'linked_product_id'], true);
+
+        $this->addForeignKey('fk_{{store_product_link}}_product', '{{store_product_link}}', 'product_id', '{{store_product}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_{{store_product_link}}_linked_product', '{{store_product_link}}', 'linked_product_id', '{{store_product}}', 'id', 'CASCADE', 'CASCADE');
+        $this->addForeignKey('fk_{{store_product_link}}_type', '{{store_product_link}}', 'type_id', '{{store_product_link_type}}', 'id', 'CASCADE', 'CASCADE');
+    }
+
+    public function safeDown()
+    {
+        $this->dropTable('{{store_product_link_type}}');
+        $this->dropTable('{{store_product_link}}');
+    }
+}

--- a/protected/modules/store/messages/en/product.php
+++ b/protected/modules/store/messages/en/product.php
@@ -92,4 +92,12 @@ return [
     'In stock' => '',
     'Not in stock' => '',
     'Stock status' => '',
+    'First you need to save the product.' => '',
+    'Linked products' => '',
+    'Link type' => '',
+    'Link types' => '',
+    'Add in' => '',
+    'Link types - manage' => '',
+    'Manage link types' => '',
+    'Code' => '',
 ];

--- a/protected/modules/store/messages/ru/product.php
+++ b/protected/modules/store/messages/ru/product.php
@@ -63,4 +63,13 @@ return [
     'Width, m.' => 'Ширина, м.',
     'You must specify the attribute value' => 'Необходимо указать значение атрибута',
     '{title} attribute is required' => 'Атрибут "{title}" обязателен',
+    'First you need to save the product.' => 'Сначала нужно сохранить товар.',
+    'Linked products' => 'Связанные товары',
+    'Link type' => 'Тип связи',
+    'Link types' => 'Типы связей',
+    'Add in' => 'Добавить в',
+    'Link types - manage' => 'Типы связей - управление',
+    'Manage link types' => 'Управление типами связей',
+    'Code' => 'Код',
+    'Title' => 'Заголовок',
 ];

--- a/protected/modules/store/models/Product.php
+++ b/protected/modules/store/models/Product.php
@@ -131,8 +131,6 @@ class Product extends yupe\models\YModel implements ICommentable
      */
     public function relations()
     {
-        // NOTE: you may need to adjust the relation name and the related
-        // class name for the relations automatically generated below.
         return [
             'type' => [self::BELONGS_TO, 'Type', 'type_id'],
             'producer' => [self::BELONGS_TO, 'Producer', 'producer_id'],
@@ -158,6 +156,7 @@ class Product extends yupe\models\YModel implements ICommentable
                 ],
                 'order' => 'comments.lft'
             ],
+            'linkedProductsRelation' => [self::HAS_MANY, 'ProductLink', 'linked_product_id'],
         ];
     }
 
@@ -258,9 +257,6 @@ class Product extends yupe\models\YModel implements ICommentable
      */
     public function search()
     {
-        // Warning: Please modify the following code to remove attributes that
-        // should not be searched.
-
         $criteria = new CDbCriteria;
 
         $criteria->compare('id', $this->id, true);
@@ -550,7 +546,7 @@ class Product extends yupe\models\YModel implements ICommentable
                 if (isset($var['id'])) {
                     $variant = ProductVariant::model()->findByPk($var['id']);
                 }
-                $variant = $variant ? : new ProductVariant();
+                $variant = $variant ?: new ProductVariant();
                 $variant->attributes = $var;
                 $variant->product_id = $this->id;
                 if ($variant->save()) {
@@ -580,7 +576,7 @@ class Product extends yupe\models\YModel implements ICommentable
 
     public function getResultPrice()
     {
-        return (float)$this->discount_price ? : (float)$this->price * (1 - ((float)$this->discount ? : 0) / 100);
+        return (float)$this->discount_price ?: (float)$this->price * (1 - ((float)$this->discount ?: 0) / 100);
     }
 
     /**
@@ -690,7 +686,7 @@ class Product extends yupe\models\YModel implements ICommentable
 
     public function getMetaTitle()
     {
-        return $this->meta_title ? : $this->name;
+        return $this->meta_title ?: $this->name;
     }
 
     public function getMetaDescription()
@@ -824,5 +820,36 @@ class Product extends yupe\models\YModel implements ICommentable
         return $absolute ?
             Yii::app()->createAbsoluteUrl('/store/catalog/show', ['name' => $this->slug]) :
             Yii::app()->createUrl('/store/catalog/show', ['name' => $this->slug]);
+    }
+
+    /**
+     * Связывает продукты
+     * @param $product Product|int Ид продукта или продукт
+     * @param null $type_id Тип связи
+     * @return bool
+     */
+    public function link($product, $type_id = null)
+    {
+        $link = new ProductLink();
+        $link->product_id = $this->id;
+        $link->linked_product_id = ($product instanceof Product ? $product->id : $product);
+        $link->type_id = $type_id;
+
+        return $link->save();
+    }
+
+    /**
+     * Список связанных с продуктом продуктов
+     * @param null|string $type_code
+     * @return Product[]
+     */
+    public function getLinkedProducts($type_code = null)
+    {
+        $criteria = new CDbCriteria();
+        $criteria->with = ['linkedProductsRelation', 'linkedProductsRelation.type'];
+        $criteria->compare('type.code', $type_code);
+        $criteria->compare('linkedProductsRelation.product_id', $this->id);
+
+        return Product::model()->findAll($criteria);
     }
 }

--- a/protected/modules/store/models/Product.php
+++ b/protected/modules/store/models/Product.php
@@ -839,17 +839,38 @@ class Product extends yupe\models\YModel implements ICommentable
     }
 
     /**
+     * @param null|string $type_code
+     * @return CDbCriteria
+     */
+    public function getLinkedProductsCriteria($type_code = null)
+    {
+        $criteria = new CDbCriteria();
+        $criteria->with = ['linkedProductsRelation', 'linkedProductsRelation.type'];
+        $criteria->together = true;
+        $criteria->compare('type.code', $type_code);
+        $criteria->compare('linkedProductsRelation.product_id', $this->id);
+
+        return $criteria;
+    }
+
+    /**
      * Список связанных с продуктом продуктов
      * @param null|string $type_code
      * @return Product[]
      */
     public function getLinkedProducts($type_code = null)
     {
-        $criteria = new CDbCriteria();
-        $criteria->with = ['linkedProductsRelation', 'linkedProductsRelation.type'];
-        $criteria->compare('type.code', $type_code);
-        $criteria->compare('linkedProductsRelation.product_id', $this->id);
+        return Product::model()->findAll($this->getLinkedProductsCriteria($type_code));
+    }
 
-        return Product::model()->findAll($criteria);
+    /**
+     * @param null|string $type_code
+     * @return CActiveDataProvider
+     */
+    public function getLinkedProductsDataProvider($type_code = null)
+    {
+        return new CActiveDataProvider(get_class($this), [
+            'criteria' => $this->getLinkedProductsCriteria($type_code),
+        ]);
     }
 }

--- a/protected/modules/store/models/ProductLink.php
+++ b/protected/modules/store/models/ProductLink.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @property integer $id
+ * @property integer $type_id
+ * @property integer $product_id
+ * @property integer $linked_product_id
+ *
+ * @property Product $product
+ * @property Product $linkedProduct
+ * @property ProductLinkType $type
+ */
+class ProductLink extends yupe\models\YModel
+{
+    public function tableName()
+    {
+        return '{{store_product_link}}';
+    }
+
+    public static function model($className = __CLASS__)
+    {
+        return parent::model($className);
+    }
+
+    public function rules()
+    {
+        return [
+            ['product_id, linked_product_id, type_id', 'required'],
+            ['product_id, linked_product_id, ', 'numerical', 'integerOnly' => true],
+            [
+                'product_id',
+                'unique',
+                'criteria' => [
+                    'condition' => 'linked_product_id = :linked_product_id',
+                    'params' => [
+                        ':linked_product_id' => $this->linked_product_id,
+                    ]
+                ]
+            ],
+            ['id, type_id, product_id, linked_product_id', 'safe', 'on' => 'search'],
+        ];
+    }
+
+
+    public function relations()
+    {
+        return [
+            'product' => [self::BELONGS_TO, 'Product', 'product_id'],
+            'linkedProduct' => [self::BELONGS_TO, 'Product', 'linked_product_id'],
+            'type' => [self::BELONGS_TO, 'ProductLinkType', 'type_id'],
+        ];
+    }
+
+    public function attributeLabels()
+    {
+        return [
+            'id' => Yii::t('StoreModule.store', 'ID'),
+            'product_id' => Yii::t('StoreModule.product', 'Product'),
+            'linked_product_id' => Yii::t('StoreModule.product', 'Linked product'),
+            'type_id' => Yii::t('StoreModule.product', 'Link type'),
+        ];
+    }
+
+    public function search()
+    {
+        $criteria = new CDbCriteria;
+
+        $criteria->compare('id', $this->id);
+        $criteria->compare('product_id', $this->product_id);
+        $criteria->compare('linked_product_id', $this->linked_product_id);
+        $criteria->compare('type_id', $this->type_id);
+
+        return new CActiveDataProvider(
+            $this, [
+                'criteria' => $criteria,
+            ]
+        );
+    }
+}

--- a/protected/modules/store/models/ProductLinkType.php
+++ b/protected/modules/store/models/ProductLinkType.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @property integer $id
+ * @property string $code
+ * @property integer $title
+ */
+class ProductLinkType extends yupe\models\YModel
+{
+    public function tableName()
+    {
+        return '{{store_product_link_type}}';
+    }
+
+    public static function model($className = __CLASS__)
+    {
+        return parent::model($className);
+    }
+
+    public function rules()
+    {
+        return [
+            ['code, title', 'filter', 'filter' => 'trim'],
+            ['code, title', 'required'],
+            ['code, title', 'length', 'max' => 255],
+            ['code', 'unique'],
+            ['title', 'unique'],
+            ['id, code, title', 'safe', 'on' => 'search'],
+        ];
+    }
+
+    public function attributeLabels()
+    {
+        return [
+            'id' => Yii::t('StoreModule.store', 'ID'),
+            'code' => Yii::t('StoreModule.product', 'Code'),
+            'title' => Yii::t('StoreModule.product', 'Title'),
+        ];
+    }
+
+    public function search()
+    {
+        $criteria = new CDbCriteria;
+
+        $criteria->compare('id', $this->id);
+        $criteria->compare('code', $this->code, true);
+        $criteria->compare('title', $this->title, true);
+
+        return new CActiveDataProvider(
+            $this, [
+                'criteria' => $criteria,
+                'sort' => ['defaultOrder' => 't.title']
+            ]
+        );
+    }
+
+    public static function getFormattedList()
+    {
+        return CHtml::listData(self::model()->findAll(['order' => 'title ASC']), 'id', 'title');
+    }
+}

--- a/protected/modules/store/models/ProductSearch.php
+++ b/protected/modules/store/models/ProductSearch.php
@@ -1,0 +1,6 @@
+<?php
+
+class ProductSearch extends Product
+{
+
+}

--- a/protected/modules/store/views/linkBackend/index_type.php
+++ b/protected/modules/store/views/linkBackend/index_type.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @var $model ProductLinkType
+ */
+
+$this->breadcrumbs = [
+    Yii::t('StoreModule.product', 'Link types') => ['/store/linkBackend/typeIndex'],
+    Yii::t('StoreModule.store', 'Manage'),
+];
+
+$this->pageTitle = Yii::t('StoreModule.product', 'Link types - manage');
+
+$this->menu = [
+    ['icon' => 'fa fa-fw fa-list-alt', 'label' => Yii::t('StoreModule.product', 'Manage link types'), 'url' => ['/store/linkBackend/typeIndex']],
+];
+?>
+<div class="page-header">
+    <h1>
+        <?= Yii::t('StoreModule.product', 'Link types') ?>
+        <small><?= Yii::t('StoreModule.store', 'manage') ?></small>
+    </h1>
+</div>
+
+<p>
+    <a class="btn btn-default btn-sm dropdown-toggle" data-toggle="collapse" data-target="#add-toggle">
+        <i class="glyphicon glyphicon-plus">&nbsp;</i>
+        <?= Yii::t('StoreModule.store', 'Add') ?>
+        <span class="caret">&nbsp;</span>
+    </a>
+</p>
+
+<div id="add-toggle" class="collapse out add-form">
+    <?php
+    /* @var $form TbActiveForm */
+    $form = $this->beginWidget(
+        'bootstrap.widgets.TbActiveForm',
+        [
+            'id' => 'question-form',
+            'enableAjaxValidation' => false,
+            'enableClientValidation' => true,
+            'action' => ['/store/linkBackend/typeCreate'],
+            'type' => 'vertical',
+            'htmlOptions' => ['class' => 'well'],
+        ]
+    ); ?>
+
+    <?php echo $form->errorSummary($model); ?>
+
+    <div class="row">
+        <div class="col-sm-6">
+            <?php echo $form->textFieldGroup($model, 'code'); ?>
+        </div>
+        <div class="col-sm-6">
+            <?php echo $form->textFieldGroup($model, 'title'); ?>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-2">
+            <?php $this->widget(
+                'bootstrap.widgets.TbButton',
+                [
+                    'buttonType' => 'submit',
+                    'context' => 'primary',
+                    'label' => Yii::t('StoreModule.store', 'Create'),
+                ]
+            ); ?>
+        </div>
+    </div>
+    <?php $this->endWidget(); ?>
+
+</div>
+
+<?php $this->widget(
+    'yupe\widgets\CustomGridView',
+    [
+        'id' => 'question-grid',
+        'dataProvider' => $model->search(),
+        'filter' => $model,
+        'actionsButtons' => false,
+        'hideBulkActions' => true,
+        'columns' => [
+            [
+                'class' => 'bootstrap.widgets.TbEditableColumn',
+                'name' => 'code',
+                'editable' => [
+                    'url' => $this->createUrl('/store/linkBackend/typeInline'),
+                    'mode' => 'inline',
+                    'params' => [
+                        Yii::app()->request->csrfTokenName => Yii::app()->request->csrfToken
+                    ]
+                ],
+                'filter' => CHtml::activeTextField($model, 'code', ['class' => 'form-control']),
+            ],
+            [
+                'class' => 'bootstrap.widgets.TbEditableColumn',
+                'name' => 'title',
+                'editable' => [
+                    'url' => $this->createUrl('/store/linkBackend/typeInline'),
+                    'mode' => 'inline',
+                    'params' => [
+                        Yii::app()->request->csrfTokenName => Yii::app()->request->csrfToken
+                    ]
+                ],
+                'filter' => CHtml::activeTextField($model, 'title', ['class' => 'form-control']),
+            ],
+            [
+                'class' => 'bootstrap.widgets.TbButtonColumn',
+                'template' => '{delete}',
+                'buttons' => [
+                    'delete' => [
+                        'url' => function ($data) {
+                            return Yii::app()->createUrl('/store/linkBackend/typeDelete', ['id' => $data->id]);
+                        }
+                    ]
+                ]
+            ],
+        ],
+    ]
+); ?>

--- a/protected/modules/store/views/productBackend/_form.php
+++ b/protected/modules/store/views/productBackend/_form.php
@@ -14,6 +14,7 @@
     <li><a href="#attributes" data-toggle="tab"><?= Yii::t("StoreModule.attr", "Attributes"); ?></a></li>
     <li><a href="#variants" data-toggle="tab"><?= Yii::t("StoreModule.store", "Variants"); ?></a></li>
     <li><a href="#seo" data-toggle="tab"><?= Yii::t("StoreModule.store", "SEO"); ?></a></li>
+    <li><a href="#linked" data-toggle="tab"><?= Yii::t("StoreModule.product", "Linked products"); ?></a></li>
 </ul>
 
 
@@ -42,116 +43,117 @@ $form = $this->beginWidget(
 
 
 <div class="tab-content">
-<div class="tab-pane active" id="common">
-    <div class="row">
-        <div class="col-sm-3">
-            <?= $form->dropDownListGroup(
-                $model,
-                'status',
-                [
-                    'widgetOptions' => [
-                        'data' => $model->getStatusList(),
-                    ],
-                ]
-            ); ?>
-        </div>
-        <div class="col-sm-3">
-            <br/>
-            <?= $form->checkBoxGroup($model, 'is_special'); ?>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-3">
-            <?= $form->dropDownListGroup(
-                $model,
-                'type_id',
-                [
-                    'widgetOptions' => [
-                        'data' => Type::model()->getFormattedList(),
-                        'htmlOptions' => [
-                            'empty' => '---',
-                            'encode' => false,
-                            'id' => 'product-type',
+    <div class="tab-pane active" id="common">
+        <div class="row">
+            <div class="col-sm-3">
+                <?= $form->dropDownListGroup(
+                    $model,
+                    'status',
+                    [
+                        'widgetOptions' => [
+                            'data' => $model->getStatusList(),
                         ],
                     ]
-                ]
-            ); ?>
+                ); ?>
+            </div>
+            <div class="col-sm-3">
+                <br/>
+                <?= $form->checkBoxGroup($model, 'is_special'); ?>
+            </div>
         </div>
-        <div class="col-sm-4">
-            <?= $form->dropDownListGroup(
-                $model,
-                'category_id',
-                [
-                    'widgetOptions' => [
-                        'data' => StoreCategory::model()->getFormattedList(),
-                        'htmlOptions' => [
-                            'empty' => '---',
-                            'encode' => false,
+        <div class="row">
+            <div class="col-sm-3">
+                <?= $form->dropDownListGroup(
+                    $model,
+                    'type_id',
+                    [
+                        'widgetOptions' => [
+                            'data' => Type::model()->getFormattedList(),
+                            'htmlOptions' => [
+                                'empty' => '---',
+                                'encode' => false,
+                                'id' => 'product-type',
+                            ],
+                        ]
+                    ]
+                ); ?>
+            </div>
+            <div class="col-sm-4">
+                <?= $form->dropDownListGroup(
+                    $model,
+                    'category_id',
+                    [
+                        'widgetOptions' => [
+                            'data' => StoreCategory::model()->getFormattedList(),
+                            'htmlOptions' => [
+                                'empty' => '---',
+                                'encode' => false,
+                            ],
                         ],
-                    ],
-                ]
-            ); ?>
+                    ]
+                ); ?>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->dropDownListGroup(
-                $model,
-                'producer_id',
-                [
-                    'widgetOptions' => [
-                        'data' => Producer::model()->getFormattedList(),
-                        'htmlOptions' => [
-                            'empty' => '---',
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->dropDownListGroup(
+                    $model,
+                    'producer_id',
+                    [
+                        'widgetOptions' => [
+                            'data' => Producer::model()->getFormattedList(),
+                            'htmlOptions' => [
+                                'empty' => '---',
+                            ],
                         ],
-                    ],
-                ]
-            ); ?>
+                    ]
+                ); ?>
+            </div>
         </div>
-    </div>
 
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->textFieldGroup($model, 'name'); ?>
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->textFieldGroup($model, 'name'); ?>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->slugFieldGroup($model, 'slug', ['sourceAttribute' => 'name']); ?>
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->slugFieldGroup($model, 'slug', ['sourceAttribute' => 'name']); ?>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'price'); ?>
+        <div class="row">
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'price'); ?>
+            </div>
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'discount_price'); ?>
+            </div>
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'discount'); ?>
+            </div>
         </div>
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'discount_price'); ?>
-        </div>
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'discount'); ?>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-sm-7">
-            <div class="panel-group" >
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <a class="panel-title collapsed" data-toggle="collapse" data-parent="#accordion_price" href="#collapse_price">
-                            <?= Yii::t("StoreModule.product", 'Additional price');?>
-                        </a>
-                    </div>
-                    <div id="collapse_price" class="panel-collapse collapse" style="height: 0px;">
-                        <div class="panel-body">
-                            <div class="row">
-                                <div class="col-sm-4">
-                                    <?= $form->textFieldGroup($model, 'purchase_price'); ?>
-                                </div>
-                                <div class="col-sm-4">
-                                    <?= $form->textFieldGroup($model, 'average_price'); ?>
-                                </div>
-                                <div class="col-sm-4">
-                                    <?= $form->textFieldGroup($model, 'recommended_price'); ?>
+        <div class="row">
+            <div class="col-sm-7">
+                <div class="panel-group">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <a class="panel-title collapsed" data-toggle="collapse" data-parent="#accordion_price" href="#collapse_price">
+                                <?= Yii::t("StoreModule.product", 'Additional price'); ?>
+                            </a>
+                        </div>
+                        <div id="collapse_price" class="panel-collapse collapse" style="height: 0px;">
+                            <div class="panel-body">
+                                <div class="row">
+                                    <div class="col-sm-4">
+                                        <?= $form->textFieldGroup($model, 'purchase_price'); ?>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <?= $form->textFieldGroup($model, 'average_price'); ?>
+                                    </div>
+                                    <div class="col-sm-4">
+                                        <?= $form->textFieldGroup($model, 'recommended_price'); ?>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -159,267 +161,274 @@ $form = $this->beginWidget(
                 </div>
             </div>
         </div>
-     </div>
-    <div class='row'>
-          <div class="col-sm-12">&nbsp;</div>
-    </div>
-    <div class='row'>
-        <div class="col-sm-7">
-            <div class="form-group">
-                <?= CHtml::label(
-                    Yii::t("StoreModule.category", 'Additional categories'),
-                    null,
-                    ['class' => 'control-label']
-                ); ?>
-                <?php $this->widget(
-                    'store.widgets.CategoryTreeWidget',
+        <div class='row'>
+            <div class="col-sm-12">&nbsp;</div>
+        </div>
+        <div class='row'>
+            <div class="col-sm-7">
+                <div class="form-group">
+                    <?= CHtml::label(
+                        Yii::t("StoreModule.category", 'Additional categories'),
+                        null,
+                        ['class' => 'control-label']
+                    ); ?>
+                    <?php $this->widget(
+                        'store.widgets.CategoryTreeWidget',
+                        [
+                            'selectedCategories' => $model->getCategoriesId(),
+                            'id' => 'category-tree'
+                        ]
+                    ); ?>
+                </div>
+            </div>
+        </div>
+
+        <div class='row'>
+            <div class="col-sm-7">
+                <?php
+                echo CHtml::image(
+                    !$model->getIsNewRecord() && $model->image ? $model->getImageUrl() : '#',
+                    $model->name,
                     [
-                        'selectedCategories' => $model->getCategoriesId(),
-                        'id' => 'category-tree'
+                        'class' => 'preview-image img-thumbnail',
+                        'style' => !$model->getIsNewRecord() && $model->image ? '' : 'display:none'
+                    ]
+                ); ?>
+
+                <?php if (!$model->isNewRecord && $model->image): ?>
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="delete-file"> <?= Yii::t('YupeModule.yupe', 'Delete the file') ?>
+                        </label>
+                    </div>
+                <?php endif; ?>
+
+                <?= $form->fileFieldGroup(
+                    $model,
+                    'image',
+                    [
+                        'widgetOptions' => [
+                            'htmlOptions' => [
+                                'onchange' => 'readURL(this);',
+                            ],
+                        ],
                     ]
                 ); ?>
             </div>
         </div>
-    </div>
 
-    <div class='row'>
-        <div class="col-sm-7">
-            <?php
-            echo CHtml::image(
-                !$model->getIsNewRecord() && $model->image ? $model->getImageUrl() : '#',
-                $model->name,
-                [
-                    'class' => 'preview-image img-thumbnail',
-                    'style' => !$model->getIsNewRecord() && $model->image ? '' : 'display:none'
-                ]
-            ); ?>
-
-            <?php if (!$model->isNewRecord && $model->image): ?>
-                <div class="checkbox">
-                    <label>
-                        <input type="checkbox" name="delete-file"> <?= Yii::t('YupeModule.yupe', 'Delete the file') ?>
-                    </label>
-                </div>
-            <?php endif; ?>
-
-            <?= $form->fileFieldGroup(
-                $model,
-                'image',
-                [
-                    'widgetOptions' => [
-                        'htmlOptions' => [
-                            'onchange' => 'readURL(this);',
-                        ],
-                    ],
-                ]
-            ); ?>
-        </div>
-    </div>
-
-    <div class='row'>
-        <div class="col-sm-12 <?= $model->hasErrors('description') ? 'has-error' : ''; ?>">
-            <?= $form->labelEx($model, 'description'); ?>
-            <?php $this->widget(
-                $this->module->getVisualEditor(),
-                [
-                    'model' => $model,
-                    'attribute' => 'description',
-                ]
-            ); ?>
-            <p class="help-block"></p>
-            <?= $form->error($model, 'description'); ?>
-        </div>
-    </div>
-
-    <div class='row'>
-        <div class="col-sm-12 <?= $model->hasErrors('short_description') ? 'has-error' : ''; ?>">
-            <?= $form->labelEx($model, 'short_description'); ?>
-            <?php $this->widget(
-                $this->module->getVisualEditor(),
-                [
-                    'model' => $model,
-                    'attribute' => 'short_description',
-                ]
-            ); ?>
-            <p class="help-block"></p>
-            <?= $form->error($model, 'short_description'); ?>
-        </div>
-    </div>
-
-    <div class='row'>
-        <div class="col-sm-12 <?= $model->hasErrors('data') ? 'has-error' : ''; ?>">
-            <?= $form->labelEx($model, 'data'); ?>
-            <?php $this->widget(
-                $this->module->getVisualEditor(),
-                [
-                    'model' => $model,
-                    'attribute' => 'data',
-                ]
-            ); ?>
-            <p class="help-block"></p>
-            <?= $form->error($model, 'data'); ?>
-        </div>
-    </div>
-</div>
-
-<div class="tab-pane" id="stock">
-    <div class="row">
-        <div class="col-sm-3">
-            <?= $form->textFieldGroup($model, 'sku'); ?>
-        </div>
-        <div class="col-sm-3">
-            <?= $form->dropDownListGroup(
-                $model,
-                'in_stock',
-                [
-                    'widgetOptions' => [
-                        'data' => $model->getInStockList(),
-                    ],
-                ]
-            ); ?>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'length'); ?>
-        </div>
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'width'); ?>
-        </div>
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'height'); ?>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-sm-2">
-            <?= $form->textFieldGroup($model, 'weight'); ?>
-        </div>
-
-        <div class="col-sm-2">
-            <?= $form->numberFieldGroup($model, 'quantity'); ?>
-        </div>
-    </div>
-
-</div>
-
-<div class="tab-pane" id="images">
-    <div class="row form-group">
-        <div class="col-sm-2">
-            <?= Yii::t("StoreModule.store", "Image"); ?>
-        </div>
-        <div class="col-sm-2">
-            <button id="button-add-image" type="button" class="btn btn-default"><i class="fa fa-fw fa-plus"></i>
-            </button>
-        </div>
-    </div>
-    <div class="row">
-        <?php $imageModel = new ProductImage(); ?>
-        <div id="product-images">
-            <div class="image-template hidden form-group">
-                <div class="row">
-                    <div class="col-sm-3">
-                        <label for=""><?= Yii::t("StoreModule.store", "File"); ?></label>
-                        <input type="file" class="image-file"/>
-                    </div>
-                    <div class="col-sm-2">
-                        <label for=""><?= Yii::t("StoreModule.store", "Title"); ?></label>
-                        <input type="text" class="image-title form-control"/>
-                    </div>
-                    <div class="col-sm-1" style="padding-top: 24px">
-                        <button class="button-delete-image btn btn-default" type="button"><i
-                                class="fa fa-fw fa-trash-o"></i></button>
-                    </div>
-                </div>
+        <div class='row'>
+            <div class="col-sm-12 <?= $model->hasErrors('description') ? 'has-error' : ''; ?>">
+                <?= $form->labelEx($model, 'description'); ?>
+                <?php $this->widget(
+                    $this->module->getVisualEditor(),
+                    [
+                        'model' => $model,
+                        'attribute' => 'description',
+                    ]
+                ); ?>
+                <p class="help-block"></p>
+                <?= $form->error($model, 'description'); ?>
             </div>
         </div>
 
-        <?php if (!$model->getIsNewRecord()): ?>
-            <?php foreach ($model->images as $image): ?>
+        <div class='row'>
+            <div class="col-sm-12 <?= $model->hasErrors('short_description') ? 'has-error' : ''; ?>">
+                <?= $form->labelEx($model, 'short_description'); ?>
+                <?php $this->widget(
+                    $this->module->getVisualEditor(),
+                    [
+                        'model' => $model,
+                        'attribute' => 'short_description',
+                    ]
+                ); ?>
+                <p class="help-block"></p>
+                <?= $form->error($model, 'short_description'); ?>
+            </div>
+        </div>
 
-                <div class="product-image">
-                    <div>
-                        <img src="<?= $image->getImageUrl(150, 150); ?>" alt="" class="img-thumbnail"/>
-                    </div>
-                    <div>
-                        <a data-id="<?= $image->id; ?>" href="<?= Yii::app()->createUrl(
-                            '/store/productBackend/deleteImage',
-                            ['id' => $image->id]
-                        ); ?>" class="pull-right product-delete-image"><i class="fa fa-fw fa-times"></i></a>
-                    </div>
-                </div>
-
-            <?php endforeach; ?>
-        <?php endif; ?>
-    </div>
-</div>
-
-<div class="tab-pane" id="attributes">
-    <div id="attributes-panel">
-        <?php $this->renderPartial('_attribute_form', ['model' => $model]); ?>
-    </div>
-</div>
-
-<div class="tab-pane" id="seo">
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->textFieldGroup($model, 'meta_title'); ?>
+        <div class='row'>
+            <div class="col-sm-12 <?= $model->hasErrors('data') ? 'has-error' : ''; ?>">
+                <?= $form->labelEx($model, 'data'); ?>
+                <?php $this->widget(
+                    $this->module->getVisualEditor(),
+                    [
+                        'model' => $model,
+                        'attribute' => 'data',
+                    ]
+                ); ?>
+                <p class="help-block"></p>
+                <?= $form->error($model, 'data'); ?>
+            </div>
         </div>
     </div>
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->textFieldGroup($model, 'meta_keywords'); ?>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-7">
-            <?= $form->textAreaGroup($model, 'meta_description'); ?>
-        </div>
-    </div>
-</div>
 
-<div class="tab-pane" id="variants">
-    <div class="row">
-        <div class="col-sm-12 form-group">
-            <label class="control-label" for=""><?= Yii::t("StoreModule.attr", "Attribute"); ?></label>
+    <div class="tab-pane" id="stock">
+        <div class="row">
+            <div class="col-sm-3">
+                <?= $form->textFieldGroup($model, 'sku'); ?>
+            </div>
+            <div class="col-sm-3">
+                <?= $form->dropDownListGroup(
+                    $model,
+                    'in_stock',
+                    [
+                        'widgetOptions' => [
+                            'data' => $model->getInStockList(),
+                        ],
+                    ]
+                ); ?>
+            </div>
+        </div>
 
-            <div class="form-inline">
-                <div class="form-group">
-                    <select id="variants-type-attributes" class="form-control"></select>
-                    <a href="#" class="btn btn-default" id="add-product-variant"><?= Yii::t(
-                            "StoreModule.store",
-                            "Add"
-                        ); ?></a>
-                </div>
+        <div class="row">
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'length'); ?>
+            </div>
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'width'); ?>
+            </div>
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'height'); ?>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-sm-2">
+                <?= $form->textFieldGroup($model, 'weight'); ?>
+            </div>
+
+            <div class="col-sm-2">
+                <?= $form->numberFieldGroup($model, 'quantity'); ?>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="tab-pane" id="images">
+        <div class="row form-group">
+            <div class="col-sm-2">
+                <?= Yii::t("StoreModule.store", "Image"); ?>
+            </div>
+            <div class="col-sm-2">
+                <button id="button-add-image" type="button" class="btn btn-default"><i class="fa fa-fw fa-plus"></i>
+                </button>
             </div>
         </div>
         <div class="row">
-            <div class="col-sm-12">
-                <div class="variant-template variant form-inline">
-                    <table>
-                        <thead>
-                        <tr>
-                            <td><?= Yii::t("StoreModule.attr", "Attribute"); ?></td>
-                            <td><?= Yii::t("StoreModule.store", "Value"); ?></td>
-                            <td><?= Yii::t("StoreModule.product", "Price type"); ?></td>
-                            <td><?= Yii::t("StoreModule.product", "Price"); ?></td>
-                            <td><?= Yii::t("StoreModule.product", "SKU"); ?></td>
-                            <td><?= Yii::t("StoreModule.store", "Order"); ?></td>
-                            <td></td>
-                        </tr>
-                        </thead>
-                        <tbody id="product-variants">
-                        <?php foreach ((array)$model->variants as $variant): ?>
-                            <?php $this->renderPartial('_variant_row', ['variant' => $variant]); ?>
-                        <?php endforeach; ?>
-                        </tbody>
-                    </table>
+            <?php $imageModel = new ProductImage(); ?>
+            <div id="product-images">
+                <div class="image-template hidden form-group">
+                    <div class="row">
+                        <div class="col-sm-3">
+                            <label for=""><?= Yii::t("StoreModule.store", "File"); ?></label>
+                            <input type="file" class="image-file"/>
+                        </div>
+                        <div class="col-sm-2">
+                            <label for=""><?= Yii::t("StoreModule.store", "Title"); ?></label>
+                            <input type="text" class="image-title form-control"/>
+                        </div>
+                        <div class="col-sm-1" style="padding-top: 24px">
+                            <button class="button-delete-image btn btn-default" type="button"><i
+                                    class="fa fa-fw fa-trash-o"></i></button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <?php if (!$model->getIsNewRecord()): ?>
+                <?php foreach ($model->images as $image): ?>
+
+                    <div class="product-image">
+                        <div>
+                            <img src="<?= $image->getImageUrl(150, 150); ?>" alt="" class="img-thumbnail"/>
+                        </div>
+                        <div>
+                            <a data-id="<?= $image->id; ?>" href="<?= Yii::app()->createUrl(
+                                '/store/productBackend/deleteImage',
+                                ['id' => $image->id]
+                            ); ?>" class="pull-right product-delete-image"><i class="fa fa-fw fa-times"></i></a>
+                        </div>
+                    </div>
+
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
+    </div>
+
+    <div class="tab-pane" id="attributes">
+        <div id="attributes-panel">
+            <?php $this->renderPartial('_attribute_form', ['model' => $model]); ?>
+        </div>
+    </div>
+
+    <div class="tab-pane" id="seo">
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->textFieldGroup($model, 'meta_title'); ?>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->textFieldGroup($model, 'meta_keywords'); ?>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-sm-7">
+                <?= $form->textAreaGroup($model, 'meta_description'); ?>
+            </div>
+        </div>
+    </div>
+
+    <div class="tab-pane" id="variants">
+        <div class="row">
+            <div class="col-sm-12 form-group">
+                <label class="control-label" for=""><?= Yii::t("StoreModule.attr", "Attribute"); ?></label>
+
+                <div class="form-inline">
+                    <div class="form-group">
+                        <select id="variants-type-attributes" class="form-control"></select>
+                        <a href="#" class="btn btn-default" id="add-product-variant"><?= Yii::t(
+                                "StoreModule.store",
+                                "Add"
+                            ); ?></a>
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-12">
+                    <div class="variant-template variant form-inline">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <td><?= Yii::t("StoreModule.attr", "Attribute"); ?></td>
+                                    <td><?= Yii::t("StoreModule.store", "Value"); ?></td>
+                                    <td><?= Yii::t("StoreModule.product", "Price type"); ?></td>
+                                    <td><?= Yii::t("StoreModule.product", "Price"); ?></td>
+                                    <td><?= Yii::t("StoreModule.product", "SKU"); ?></td>
+                                    <td><?= Yii::t("StoreModule.store", "Order"); ?></td>
+                                    <td></td>
+                                </tr>
+                            </thead>
+                            <tbody id="product-variants">
+                                <?php foreach ((array)$model->variants as $variant): ?>
+                                    <?php $this->renderPartial('_variant_row', ['variant' => $variant]); ?>
+                                <?php endforeach; ?>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
+
+    <div class="tab-pane" id="linked">
+        <?php if ($model->isNewRecord): ?>
+            <?= Yii::t("StoreModule.product", "First you need to save the product."); ?>
+        <?php else: ?>
+            <?= $this->renderPartial('_link_form', ['product' => $model]) ?>
+        <?php endif; ?>
+    </div>
 </div>
 
 <br/>
@@ -428,8 +437,8 @@ $form = $this->beginWidget(
     'bootstrap.widgets.TbButton',
     [
         'buttonType' => 'submit',
-        'context'    => 'primary',
-        'label'      => $model->getIsNewRecord() ? Yii::t('StoreModule.product', 'Add product and continue') : Yii::t(
+        'context' => 'primary',
+        'label' => $model->getIsNewRecord() ? Yii::t('StoreModule.product', 'Add product and continue') : Yii::t(
             'StoreModule.product',
             'Save product and continue'
         ),
@@ -439,9 +448,9 @@ $form = $this->beginWidget(
 <?php $this->widget(
     'bootstrap.widgets.TbButton',
     [
-        'buttonType'  => 'submit',
+        'buttonType' => 'submit',
         'htmlOptions' => ['name' => 'submit-type', 'value' => 'index'],
-        'label'       => $model->getIsNewRecord() ? Yii::t('StoreModule.product', 'Add product and close') : Yii::t(
+        'label' => $model->getIsNewRecord() ? Yii::t('StoreModule.product', 'Add product and close') : Yii::t(
             'StoreModule.product',
             'Save product and close'
         ),

--- a/protected/modules/store/views/productBackend/_link_form.php
+++ b/protected/modules/store/views/productBackend/_link_form.php
@@ -1,0 +1,222 @@
+<?php
+/* @var $searchModel ProductSearch */
+/* @var $product Product */
+
+if (!isset($searchModel)) {
+    $searchModel = new ProductSearch('search');
+    $searchModel->unsetAttributes();
+}
+
+$linkTypes = ProductLinkType::getFormattedList();
+
+?>
+
+<?php if (isset($product)): ?>
+    <div class="row">
+        <div class="col-sm-12">
+            <?php
+            $linked = new ProductLink('search');
+            $linked->setAttributes(Yii::app()->getRequest()->getParam('ProductLink'));
+            $linked->product_id = $product->id;
+            $this->widget(
+                'yupe\widgets\CustomGridView',
+                [
+                    'id' => 'linked-product-grid',
+                    'type' => 'condensed',
+                    'dataProvider' => $linked->search(),
+                    'filter' => $linked,
+                    'hideBulkActions' => true,
+                    'ajaxUrl' => ['/store/productBackend/update', 'id' => $product->id],
+                    'columns' => [
+                        [
+                            'name' => 'id',
+                            'value' => function ($data) {
+                                return $data->linkedProduct->id;
+                            },
+                            'filter' => false,
+                        ],
+                        [
+                            'type' => 'raw',
+                            'value' => function ($data) {
+                                return CHtml::image($data->linkedProduct->getImageUrl(40, 40), "", ["class" => "img-thumbnail"]);
+                            },
+                        ],
+                        [
+                            'header' => Yii::t('StoreModule.store', 'Name'),
+                            'type' => 'raw',
+                            'value' => function ($data) {
+                                return CHtml::link($data->linkedProduct->name, ["/store/productBackend/update", "id" => $data->linkedProduct->id]);
+                            },
+                        ],
+                        [
+                            'header' => Yii::t('StoreModule.product', 'SKU'),
+                            'type' => 'raw',
+                            'value' => function ($data) {
+                                return CHtml::link($data->linkedProduct->sku, ["/store/productBackend/update", "id" => $data->linkedProduct->id]);
+                            },
+                        ],
+                        [
+                            'header' => Yii::t('StoreModule.product', 'Price'),
+                            'type' => 'raw',
+                            'value' => function ($data) {
+                                return $data->linkedProduct->price;
+                            },
+                        ],
+                        [
+                            'class' => 'yupe\widgets\EditableStatusColumn',
+                            'name' => 'type_id',
+                            'url' => $this->createUrl('/store/linkBackend/inline'),
+                            'source' => $linkTypes,
+                            'options' => [
+
+                            ],
+                        ],
+                        [
+                            'class' => 'yupe\widgets\CustomButtonColumn',
+                            'template' => '{delete}',
+                            'buttons' => [
+                                'delete' => [
+                                    'url' => function ($data) {
+                                        return Yii::app()->createUrl('/store/link/delete', ['id' => $data->id]);
+                                    }
+                                ]
+                            ]
+                        ],
+                    ],
+                ]
+            ); ?>
+        </div>
+    </div>
+
+<?php endif; ?>
+
+<div class="row">
+    <div class="col-sm-12">
+        <?php
+
+        $this->widget(
+            'yupe\widgets\CustomGridView',
+            [
+                'id' => 'product-grid',
+                'type' => 'condensed',
+                'dataProvider' => $searchModel->search(),
+                'filter' => $searchModel,
+                'hideBulkActions' => true,
+                'ajaxUrl' => ['/store/linkBackend/index'],
+                'columns' => [
+                    [
+                        'type' => 'raw',
+                        'value' => function ($data) {
+                            return CHtml::image($data->getImageUrl(40, 40), "", ["class" => "img-thumbnail"]);
+                        },
+                    ],
+                    [
+                        'name' => 'name',
+                        'type' => 'raw',
+                        'value' => function ($data) {
+                            return CHtml::link($data->name, ["/store/productBackend/update", "id" => $data->id]);
+                        },
+                    ],
+                    [
+                        'class' => 'bootstrap.widgets.TbEditableColumn',
+                        'name' => 'sku',
+                        'editable' => [
+                            'emptytext' => '---',
+                            'url' => $this->createUrl('/store/productBackend/inline'),
+                            'mode' => 'inline',
+                            'params' => [
+                                Yii::app()->getRequest()->csrfTokenName => Yii::app()->getRequest()->csrfToken
+                            ]
+                        ],
+                        'filter' => CHtml::activeTextField($searchModel, 'sku', ['class' => 'form-control']),
+                    ],
+                    [
+                        'name' => 'category_id',
+                        'value' => function ($data) {
+                            $categoryList = '<span class="label label-primary">' . (isset($data->mainCategory) ? $data->mainCategory->name : '---') . '</span>';
+
+                            foreach ($data->categories as $category) {
+                                $categoryList .= '<br>' . $category->name;
+                            }
+
+                            return $categoryList;
+                        },
+                        'type' => 'raw',
+                        'filter' => CHtml::activeDropDownList($searchModel, 'category', StoreCategory::model()->getFormattedList(), ['encode' => false, 'empty' => '', 'class' => 'form-control']),
+                        'htmlOptions' => ['width' => '220px'],
+                    ],
+                    [
+                        'class' => 'bootstrap.widgets.TbEditableColumn',
+                        'name' => 'price',
+                        'value' => function ($data) {
+                            return (float)$data->price;
+                        },
+                        'editable' => [
+                            'url' => $this->createUrl('/store/productBackend/inline'),
+                            'mode' => 'inline',
+                            'params' => [
+                                Yii::app()->getRequest()->csrfTokenName => Yii::app()->getRequest()->csrfToken
+                            ]
+                        ],
+                        'filter' => CHtml::activeTextField($searchModel, 'price', ['class' => 'form-control']),
+                    ],
+                    [
+                        'value' => function ($data) use ($linkTypes) {
+                            $links = [];
+
+                            foreach ($linkTypes as $id => $name) {
+                                $links[] = [
+                                    'label' => $name,
+                                    'linkOptions' => ['class' => 'link-product-button', 'data-type-id' => $id, 'data-linked-product-id' => $data->id,],
+                                    'url' => '#',
+                                ];
+                            }
+
+                            return $this->widget(
+                                'booster.widgets.TbButtonGroup',
+                                [
+                                    'buttons' => [
+                                        [
+                                            'label' => Yii::t('StoreModule.product', 'Add in'),
+                                            'items' => $links,
+                                        ]
+                                    ],
+                                ],
+                                true
+                            );
+                        },
+                        'type' => 'raw',
+                    ]
+                ],
+            ]
+        ); ?>
+    </div>
+</div>
+
+<?php
+$productId = isset($product) ? $product->id : null;
+$linkUrl = Yii::app()->createUrl('/store/linkBackend/link');
+$tokenName = Yii::app()->getRequest()->csrfTokenName;
+$token = Yii::app()->getRequest()->csrfToken;
+Yii::app()->getClientScript()->registerScript(__FILE__, <<<JS
+    $('body').on('click', '.link-product-button', function (e) {
+        e.preventDefault();
+        var button = $(this);
+        var data = {
+            product_id: $productId,
+            linked_product_id: button.data('linked-product-id'),
+            type_id: button.data('type-id'),
+            "$tokenName": "$token"
+        };
+        $.ajax({
+            url: "$linkUrl",
+            type: 'post',
+            data: data,
+            success: function(data){
+                $.fn.yiiGridView.update('linked-product-grid');
+            }
+        });
+    })
+JS
+); ?>
+

--- a/protected/modules/store/views/productBackend/_link_form.php
+++ b/protected/modules/store/views/productBackend/_link_form.php
@@ -77,7 +77,7 @@ $linkTypes = ProductLinkType::getFormattedList();
                             'buttons' => [
                                 'delete' => [
                                     'url' => function ($data) {
-                                        return Yii::app()->createUrl('/store/link/delete', ['id' => $data->id]);
+                                        return Yii::app()->createUrl('/store/linkBackend/delete', ['id' => $data->id]);
                                     }
                                 ]
                             ]

--- a/protected/modules/store/widgets/LinkedProductsWidget.php
+++ b/protected/modules/store/widgets/LinkedProductsWidget.php
@@ -1,0 +1,21 @@
+<?php
+
+class LinkedProductsWidget extends \yupe\widgets\YWidget
+{
+    public $view = 'linked-products';
+
+    public $code = null;
+    /**
+     * @var Product
+     */
+    public $product;
+
+    public function run()
+    {
+        if (!$this->product) {
+            return;
+        }
+
+        $this->render($this->view, ['dataProvider' => $this->product->getLinkedProductsDataProvider($this->code)]);
+    }
+} 

--- a/protected/modules/yupe/widgets/EditableStatusColumn.php
+++ b/protected/modules/yupe/widgets/EditableStatusColumn.php
@@ -80,7 +80,7 @@ class EditableStatusColumn extends \TbEditableColumn
             $this->filter = $this->source;
         }
 
-        if (is_array($this->filter)) {
+        if (is_array($this->filter) && $this->grid->filter) {
             $this->filter = CHtml::activeDropDownList($this->grid->filter, $this->name, $this->filter, ['id' => false, 'prompt' => '', 'class' => 'form-control']);
         }
 

--- a/themes/default/views/store/catalog/product.php
+++ b/themes/default/views/store/catalog/product.php
@@ -19,208 +19,211 @@ $this->breadcrumbs = array_merge(
 );
 ?>
 <div class="row">
-<div class="col-sm-12">
-<div class="row">
     <div class="col-sm-12">
-        <span class="title"><?= CHtml::encode($product->name); ?></span>
-    </div>
-</div>
-<div class="row">
-    <div class="col-sm-12 product-feature">
         <div class="row">
-            <div class="col-sm-4">
-                <div class="thumbnails">
-                    <div class="image-preview">
-                        <img src="<?= $product->getImageUrl(); ?>" alt="" class="" id="main-image">
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-4 col-md-4">
-                            <a href="<?= $product->getImageUrl(); ?>" class="thumbnail">
-                                <img src="<?= $product->getImageUrl(50, 50); ?>"/>
-                            </a>
-                        </div>
-                        <?php foreach ($product->getImages() as $key => $image): { ?>
-                            <div class="col-xs-4 col-md-4">
-                                <a href="<?= $image->getImageUrl(); ?>" class="thumbnail">
-                                    <img src="<?= $image->getImageUrl(50, 50); ?>"/>
-                                </a>
-                            </div>
-                        <?php } endforeach; ?>
-                    </div>
-                </div>
+            <div class="col-sm-12">
+                <span class="title"><?= CHtml::encode($product->name); ?></span>
             </div>
-            <div class="col-sm-8">
-                <?= $product->isInStock() ? Yii::t("StoreModule.product", "In stock") : Yii::t(
-                    "StoreModule.product",
-                    "Not in stock"
-                ); ?>
-                <br/>
-                <?= $product->quantity; ?> <?= Yii::t("StoreModule.product", "in stock"); ?>
-                <br/>
-                <br/>
+        </div>
+        <div class="row">
+            <div class="col-sm-12 product-feature">
+                <div class="row">
+                    <div class="col-sm-4">
+                        <div class="thumbnails">
+                            <div class="image-preview">
+                                <img src="<?= $product->getImageUrl(); ?>" alt="" class="" id="main-image">
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-4 col-md-4">
+                                    <a href="<?= $product->getImageUrl(); ?>" class="thumbnail">
+                                        <img src="<?= $product->getImageUrl(50, 50); ?>"/>
+                                    </a>
+                                </div>
+                                <?php foreach ($product->getImages() as $key => $image): { ?>
+                                    <div class="col-xs-4 col-md-4">
+                                        <a href="<?= $image->getImageUrl(); ?>" class="thumbnail">
+                                            <img src="<?= $image->getImageUrl(50, 50); ?>"/>
+                                        </a>
+                                    </div>
+                                <?php } endforeach; ?>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-8">
+                        <?= $product->isInStock() ? Yii::t("StoreModule.product", "In stock") : Yii::t(
+                            "StoreModule.product",
+                            "Not in stock"
+                        ); ?>
+                        <br/>
+                        <?= $product->quantity; ?> <?= Yii::t("StoreModule.product", "in stock"); ?>
+                        <br/>
+                        <br/>
 
-                <div class="properties">
-                    <?php foreach ($product->getAttributeGroups() as $groupName => $items): { ?>
-                        <div class="propertyGroup">
-                            <h4>
-                                <span><?= CHtml::encode($groupName); ?></span>
-                            </h4>
-                            <table>
-                                <tbody>
-                                <?php foreach ($items as $attribute): { ?>
+                        <div class="properties">
+                            <?php foreach ($product->getAttributeGroups() as $groupName => $items): { ?>
+                                <div class="propertyGroup">
+                                    <h4>
+                                        <span><?= CHtml::encode($groupName); ?></span>
+                                    </h4>
+                                    <table>
+                                        <tbody>
+                                            <?php foreach ($items as $attribute): { ?>
+                                                <tr>
+                                                    <td class="key">
+                                                        <span><?= CHtml::encode($attribute->title); ?></span>
+                                                    </td>
+                                                    <td class="value">
+                                                        <?= $attribute->renderValue($product->attr($attribute->name)); ?>
+                                                    </td>
+                                                </tr>
+                                            <?php } endforeach; ?>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            <?php } endforeach; ?>
+                        </div>
+                        <br/>
+                        <h4><?= Yii::t("StoreModule.store", "Description"); ?></h4>
+                        <?= $product->short_description; ?>
+                        <hr>
+                        <h4><?= Yii::t("StoreModule.store", "Variants"); ?></h4>
+
+                        <form action="<?= Yii::app()->createUrl('cart/cart/add'); ?>" method="post">
+                            <input type="hidden" name="Product[id]" value="<?= $product->id; ?>"/>
+                            <?= CHtml::hiddenField(
+                                Yii::app()->getRequest()->csrfTokenName,
+                                Yii::app()->getRequest()->csrfToken
+                            ); ?>
+                            <table class="table table-condensed">
+                                <?php foreach ($product->getVariantsGroup() as $title => $variantsGroup): { ?>
                                     <tr>
-                                        <td class="key">
-                                            <span><?= CHtml::encode($attribute->title); ?></span>
+                                        <td style="padding: 0;">
+                                            <?= CHtml::encode($title); ?>
                                         </td>
-                                        <td class="value">
-                                            <?= $attribute->renderValue($product->attr($attribute->name)); ?>
+                                        <td>
+                                            <?=
+                                            CHtml::dropDownList(
+                                                'ProductVariant[]',
+                                                null,
+                                                CHtml::listData($variantsGroup, 'id', 'optionValue'),
+                                                ['empty' => '', 'class' => 'form-control', 'options' => $product->getVariantsOptions()]
+                                            ); ?>
                                         </td>
                                     </tr>
                                 <?php } endforeach; ?>
-                                </tbody>
                             </table>
-                        </div>
-                    <?php } endforeach; ?>
-                </div>
-                <br/>
-                <h4><?= Yii::t("StoreModule.store", "Description"); ?></h4>
-                <?= $product->short_description; ?>
-                <hr>
-                <h4><?= Yii::t("StoreModule.store", "Variants"); ?></h4>
+                            <div>
+                                <input type="hidden" id="base-price" value="<?= round($product->getResultPrice(), 2); ?>"/>
 
-                <form action="<?= Yii::app()->createUrl('cart/cart/add'); ?>" method="post">
-                    <input type="hidden" name="Product[id]" value="<?= $product->id; ?>"/>
-                    <?= CHtml::hiddenField(
-                        Yii::app()->getRequest()->csrfTokenName,
-                        Yii::app()->getRequest()->csrfToken
-                    ); ?>
-                    <table class="table table-condensed">
-                        <?php foreach ($product->getVariantsGroup() as $title => $variantsGroup): { ?>
-                            <tr>
-                                <td style="padding: 0;">
-                                    <?= CHtml::encode($title); ?>
-                                </td>
-                                <td>
-                                    <?=
-                                    CHtml::dropDownList(
-                                        'ProductVariant[]',
-                                        null,
-                                        CHtml::listData($variantsGroup, 'id', 'optionValue'),
-                                        ['empty' => '', 'class' => 'form-control', 'options' => $product->getVariantsOptions()]
-                                    ); ?>
-                                </td>
-                            </tr>
-                        <?php } endforeach; ?>
-                    </table>
-                    <div>
-                        <input type="hidden" id="base-price" value="<?= round($product->getResultPrice(), 2); ?>"/>
+                                <p>
+                                    <?= Yii::t("StoreModule.product", "Price"); ?>
+                                    : <?= round($product->getBasePrice(), 2); ?> <?= Yii::t("StoreModule.product", "RUB"); ?>
+                                </p>
 
-                        <p>
-                            <?= Yii::t("StoreModule.product", "Price"); ?>
-                            : <?= round($product->getBasePrice(), 2); ?> <?= Yii::t("StoreModule.product", "RUB"); ?>
-                        </p>
+                                <p>
+                                    <?= Yii::t("StoreModule.product", "Fix price with discount"); ?>
+                                    : <?= round($product->getDiscountPrice(), 2); ?>
+                                    <?= Yii::t("StoreModule.product", "RUB"); ?>
+                                </p>
 
-                        <p>
-                            <?= Yii::t("StoreModule.product", "Fix price with discount"); ?>
-                            : <?= round($product->getDiscountPrice(), 2); ?>
-                            <?= Yii::t("StoreModule.product", "RUB"); ?>
-                        </p>
+                                <p>
+                                    <?= Yii::t("StoreModule.product", "Discount"); ?>: <?= round($product->discount); ?>%
+                                </p>
 
-                        <p>
-                            <?= Yii::t("StoreModule.product", "Discount"); ?>: <?= round($product->discount); ?>%
-                        </p>
+                                <p>
+                                    <?= Yii::t("StoreModule.product", "Total price"); ?>: <span
+                                        id="result-price"><?= round($product->getResultPrice(), 2); ?></span>
+                                    <?= Yii::t("StoreModule.product", "RUB"); ?>
+                                </p>
+                            </div>
 
-                        <p>
-                            <?= Yii::t("StoreModule.product", "Total price"); ?>: <span
-                                id="result-price"><?= round($product->getResultPrice(), 2); ?></span>
-                            <?= Yii::t("StoreModule.product", "RUB"); ?>
-                        </p>
-                    </div>
+                            <?php if (Yii::app()->hasModule('order')): ?>
+                                <div class="row">
+                                    <div class="col-sm-3">
+                                        <div class="input-group">
+                                            <div class="input-group-btn">
+                                                <button class="btn btn-default product-quantity-decrease" type="button">-
+                                                </button>
+                                            </div>
+                                            <input type="text" class="text-center form-control" value="1"
+                                                   name="Product[quantity]" id="product-quantity"/>
 
-                    <?php if (Yii::app()->hasModule('order')): ?>
-                        <div class="row">
-                            <div class="col-sm-3">
-                                <div class="input-group">
-                                    <div class="input-group-btn">
-                                        <button class="btn btn-default product-quantity-decrease" type="button">-
-                                        </button>
+                                            <div class="input-group-btn">
+                                                <button class="btn btn-default product-quantity-increase" type="button">+
+                                                </button>
+                                            </div>
+                                        </div>
                                     </div>
-                                    <input type="text" class="text-center form-control" value="1"
-                                           name="Product[quantity]" id="product-quantity"/>
-
-                                    <div class="input-group-btn">
-                                        <button class="btn btn-default product-quantity-increase" type="button">+
+                                    <div class="col-sm-6">
+                                        <button class="btn btn-success pull-left" id="add-product-to-cart"
+                                                data-loading-text="<?= Yii::t("StoreModule.store", "Adding"); ?>">
+                                            <?= Yii::t("StoreModule.store", "Add to cart"); ?>
                                         </button>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-sm-6">
-                                <button class="btn btn-success pull-left" id="add-product-to-cart"
-                                        data-loading-text="<?= Yii::t("StoreModule.store", "Adding"); ?>">
-                                    <?= Yii::t("StoreModule.store", "Add to cart"); ?>
-                                </button>
-                            </div>
-                        </div>
-                    <?php endif; ?>
-                </form>
-                <br>
-                <hr>
+                            <?php endif; ?>
+                        </form>
+                        <br>
+                        <hr>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="clearfix"></div>
+        <ul class="nav nav-tabs" id="myTab">
+            <li class="active"><a href="#description" data-toggle="tab"><?= Yii::t("StoreModule.store", "Description"); ?></a>
+            </li>
+            <li><a href="#data" data-toggle="tab"><?= Yii::t("StoreModule.store", "Data"); ?></a></li>
+            <li><a href="#attributes" data-toggle="tab"><?= Yii::t("StoreModule.store", "Characteristics"); ?></a></li>
+            <li><a href="#comments-tab" data-toggle="tab"><?= Yii::t("StoreModule.store", "Comments"); ?></a></li>
+        </ul>
+
+        <div class="tab-content">
+            <div class="tab-pane active" id="description">
+                <?= $product->description; ?>
+            </div>
+            <div class="tab-pane" id="data">
+                <?= $product->data; ?>
+            </div>
+            <div class="tab-pane" id="attributes">
+                <table>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.producer", "Producer"); ?>:</b></td>
+                        <td><?= CHtml::encode($product->getProducerName()); ?></td>
+                    </tr>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.product", "SKU"); ?>:</b></td>
+                        <td><?= CHtml::encode($product->sku); ?></td>
+                    </tr>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.product", "Length"); ?>:</b></td>
+                        <td><?= round($product->length, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
+                    </tr>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.product", "Width"); ?>:</b></td>
+                        <td><?= round($product->width, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
+                    </tr>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.product", "Height"); ?>:</b></td>
+                        <td><?= round($product->height, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
+                    </tr>
+                    <tr>
+                        <td><b><?= Yii::t("StoreModule.product", "Weight"); ?>:</b></td>
+                        <td><?= round($product->weight, 2); ?> <?= Yii::t("StoreModule.product", "kg"); ?></td>
+                    </tr>
+                </table>
+            </div>
+            <div class="tab-pane" id="comments-tab">
+                <?php $this->widget('application.modules.comment.widgets.CommentsWidget', [
+                    'redirectTo' => $product->getUrl(),
+                    'model' => $product,
+                ]); ?>
             </div>
         </div>
     </div>
-</div>
-<div class="clearfix"></div>
-<ul class="nav nav-tabs" id="myTab">
-    <li class="active"><a href="#description" data-toggle="tab"><?= Yii::t("StoreModule.store", "Description"); ?></a>
-    </li>
-    <li><a href="#data" data-toggle="tab"><?= Yii::t("StoreModule.store", "Data"); ?></a></li>
-    <li><a href="#attributes" data-toggle="tab"><?= Yii::t("StoreModule.store", "Characteristics"); ?></a></li>
-    <li><a href="#comments-tab" data-toggle="tab"><?= Yii::t("StoreModule.store", "Comments"); ?></a></li>
-</ul>
-
-<div class="tab-content">
-    <div class="tab-pane active" id="description">
-        <?= $product->description; ?>
+    <div class="col-sm-12">
+        <?php $this->widget('application.modules.store.widgets.LinkedProductsWidget', ['product' => $product, 'code' => null,]); ?>
     </div>
-    <div class="tab-pane" id="data">
-        <?= $product->data; ?>
-    </div>
-    <div class="tab-pane" id="attributes">
-        <table>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.producer", "Producer"); ?>:</b></td>
-                <td><?= CHtml::encode($product->getProducerName()); ?></td>
-            </tr>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.product", "SKU"); ?>:</b></td>
-                <td><?= CHtml::encode($product->sku); ?></td>
-            </tr>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.product", "Length"); ?>:</b></td>
-                <td><?= round($product->length, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
-            </tr>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.product", "Width"); ?>:</b></td>
-                <td><?= round($product->width, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
-            </tr>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.product", "Height"); ?>:</b></td>
-                <td><?= round($product->height, 2); ?> <?= Yii::t("StoreModule.product", "m"); ?></td>
-            </tr>
-            <tr>
-                <td><b><?= Yii::t("StoreModule.product", "Weight"); ?>:</b></td>
-                <td><?= round($product->weight, 2); ?> <?= Yii::t("StoreModule.product", "kg"); ?></td>
-            </tr>
-        </table>
-    </div>
-    <div class="tab-pane" id="comments-tab">
-        <?php $this->widget('application.modules.comment.widgets.CommentsWidget', [
-            'redirectTo' => $product->getUrl(),
-            'model' => $product,
-        ]); ?>
-    </div>
-</div>
-</div>
 </div>
 
 <?php Yii::app()->getClientScript()->registerScript(
@@ -230,4 +233,4 @@ $this->breadcrumbs = array_merge(
     mainImage: "#main-image"
 });
 JS
-);?>
+); ?>

--- a/themes/default/views/store/widgets/LinkedProductsWidget/_view.php
+++ b/themes/default/views/store/widgets/LinkedProductsWidget/_view.php
@@ -1,0 +1,28 @@
+<?php $productUrl = Yii::app()->createUrl('/store/catalog/show', ['name' => CHtml::encode($data->slug)]); ?>
+<div class="col-sm-4 col-item-block">
+    <div class="col-item">
+        <div class="photo">
+            <a href="<?= $productUrl; ?>">
+                <img src="<?= $data->getImageUrl(190, 190); ?>"/>
+            </a>
+        </div>
+        <div class="info separator">
+            <div class="row">
+                <div class="price col-sm-12">
+                    <h5>
+                        <a href="<?= $productUrl; ?>"><?= CHtml::encode($data->getName()); ?></a>
+                    </h5>
+                    <h5 class="price-text-color">
+                        <?= $data->getResultPrice(); ?> <i class="fa fa-rub"></i>
+                    </h5>
+                </div>
+            </div>
+            <div class="separator clear-left">
+                <?php if (Yii::app()->hasModule('cart')): ?>
+                    <a href="#" class="btn btn-add btn-success btn-block hidden-sm quick-add-product-to-cart" data-product-id="<?= $data->id; ?>" data-cart-add-url="<?= Yii::app()->createUrl('/cart/cart/add');?>"><i class="glyphicon glyphicon-shopping-cart"></i></a>
+                <?php endif; ?>
+            </div>
+            <div class="clearfix"></div>
+        </div>
+    </div>
+</div>

--- a/themes/default/views/store/widgets/LinkedProductsWidget/linked-products.php
+++ b/themes/default/views/store/widgets/LinkedProductsWidget/linked-products.php
@@ -1,0 +1,16 @@
+<?php /* @var $dataProvider CActiveDataProvider */ ?>
+<h3>
+    <?= Yii::t('StoreModule.product', 'Linked products') ?>
+</h3>
+
+<?php $this->widget(
+    'zii.widgets.CListView',
+    [
+        'dataProvider' => $dataProvider,
+        'template' => '{items}',
+        'itemView' => '_view',
+        'cssFile' => false,
+        'pager' => false,
+    ]
+); ?>
+


### PR DESCRIPTION
Добавляет возможность привязки товаров друг к другу. 
Можно настраивать группы связей, например, сопутствующие, похожие и т.д.
Получить список привязанных товаров:
```php
 // вернет список моделей, которые связаны типом similar
$product->getLinkedProducts('similar');
$product->getLinkedProducts(['similar', 'related']);
$product->getLinkedProducts(); // все
```

Виджет для вывода связанных товаров:
```php
$this->widget('application.modules.store.widgets.LinkedProductsWidget', ['product' => $product, 'code' => 'similar']);
```