### PR TITLE
#1878 Сохранение состояния фильтра

### DIFF
--- a/protected/modules/page/controllers/PageBackendController.php
+++ b/protected/modules/page/controllers/PageBackendController.php
@@ -328,15 +328,6 @@ class PageBackendController extends yupe\components\controllers\BackController
     {
         $model = new Page('search');
 
-        $model->unsetAttributes();
-
-        $model->setAttributes(
-            Yii::app()->getRequest()->getParam(
-                'Page',
-                []
-            )
-        );
-
         $this->render(
             'index',
             [

--- a/protected/modules/yupe/components/FilterState.php
+++ b/protected/modules/yupe/components/FilterState.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Класс управления состояниями фильтра данных
+ *
+ * @category YupeComponents
+ * @package  yupe.modules.yupe.components
+ *
+ * @author   Oleg Filimonov <olegsabian@gmail.com>
+ * @license  https://github.com/yupe/yupe/blob/master/LICENSE BSD
+ * @link     http://yupe.ru - основной сайт
+ *
+ **/
+namespace yupe\components;
+
+use Yii;
+use yupe\models\YModel;
+
+class FilterState
+{
+    private $model;
+    private $prefix;
+    private $request;
+
+    public function __construct(YModel $model)
+    {
+        $this->model = $model;
+        $this->prefix = get_class($model);
+        $this->request = Yii::app()->getRequest();
+    }
+
+    public function run()
+    {
+        if ($this->request->getQuery('clearFilters') == 1) {
+            $this->clear();
+        }
+
+        $query = $this->request->getQuery($this->prefix);
+
+        if (isset($query)) {
+            $this->model->attributes = $query;
+            $this->setValues();
+        } else {
+            $this->getValues();
+        }
+
+        $this->setControls('page');
+        $this->setControls('sort');
+    }
+
+    /**
+     * Очищает все значения фильтра
+     */
+    public function clear()
+    {
+        $this->model->unsetAttributes();
+
+        foreach ($this->getAttributes() as $attribute) {
+            $this->setValue($attribute);
+        }
+
+        $this->setValue('page');
+        $this->setValue('sort');
+    }
+
+    /**
+     * Возвращает все безопасные атрибуты модели
+     *
+     * @return array
+     */
+    private function getAttributes()
+    {
+        return $this->model->getSafeAttributeNames();
+    }
+
+    /**
+     * Возвращает значение атрибута из сессии пользователя
+     *
+     * @param $name
+     * @return mixed
+     */
+    private function getValue($name)
+    {
+        return Yii::app()->user->getState($this->prefix . $name);
+    }
+
+    /**
+     * Записывает значение атрибута в сессию пользователя
+     *
+     * @param $name
+     * @param int $value
+     */
+    private function setValue($name, $value = 1)
+    {
+        Yii::app()->user->setState($this->prefix . $name, $value, 1);
+    }
+
+    /**
+     * Массовое присваивание сохраненных значений атрибутам модели
+     */
+    private function getValues()
+    {
+        foreach ($this->getAttributes() as $attribute) {
+            if (null !== ($value = $this->getValue($attribute))) {
+                $this->model->$attribute = $value;
+            }
+        }
+    }
+
+    /**
+     * Сохранение всех значений атрибутов модели
+     */
+    private function setValues()
+    {
+        foreach ($this->getAttributes() as $attribute) {
+            $this->setValue($attribute, $this->model->$attribute);
+        }
+    }
+
+    /**
+     * Управление значениями не являющимися атрибутами модели (сортировка, пагинация)
+     *
+     * @param $name
+     */
+    private function setControls($name)
+    {
+        $key = $this->prefix . '_' . $name;
+        $query = $this->request->getQuery($key);
+
+        if (!empty($query)) {
+            $this->setValue($name, $query);
+        } elseif (!empty($_GET['ajax'])) {
+            $this->setValue($name);
+        } else {
+            $val = $this->getValue($name);
+            if (!empty($val)) {
+                $_GET[$key] = $val;
+            }
+        }
+    }
+}

--- a/protected/modules/yupe/messages/ru/yupe.php
+++ b/protected/modules/yupe/messages/ru/yupe.php
@@ -350,4 +350,5 @@ return [
     'Record was deleted!' => 'Запись успешно удалена!',
     'Record was not found!' => 'Запись не найдена!',
     'Delete the file' => 'Удалить файл',
+    'Clear Filters' => 'Очистить фильтр',
 ];

--- a/protected/modules/yupe/models/YModel.php
+++ b/protected/modules/yupe/models/YModel.php
@@ -22,6 +22,7 @@ use TagsCache;
 use CCacheDependency;
 use CChainedCacheDependency;
 use Yii;
+use yupe\components\FilterState;
 
 abstract class YModel extends CActiveRecord
 {
@@ -62,6 +63,16 @@ abstract class YModel extends CActiveRecord
     public static function _CLASS_()
     {
         return get_called_class();
+    }
+
+    public function afterConstruct()
+    {
+        if ($this->scenario === 'search') {
+            $filter = new FilterState($this);
+            $filter->run();
+        }
+
+        parent::afterConstruct();
     }
 
     /**

--- a/protected/modules/yupe/widgets/CustomButtonColumn.php
+++ b/protected/modules/yupe/widgets/CustomButtonColumn.php
@@ -28,4 +28,15 @@ class CustomButtonColumn extends \TbButtonColumn
      * @var string the delete button icon (defaults to 'trash').
      */
     public $deleteButtonIcon = 'fa fa-fw fa-trash-o';
+
+    public function renderFilterCell()
+    {
+        echo '<td class="button-column">';
+        $this->renderButton('clear', [
+            'label' => Yii::t('YupeModule.yupe', 'Clear Filters'),
+            'icon' => 'fa fa-fw fa-undo',
+            'url' => 'Yii::app()->controller->createUrl(Yii::app()->controller->action->ID,array("clearFilters"=>1))'
+        ],[],[]);
+        echo '</td>';
+    }
 }


### PR DESCRIPTION
Предлагаю свой вариант решения сохранения состояния фильтра.
При наличии пагинации запоминает текущую страницу, состояния сортировки полей, ну и само собой фильтры. Все состояния сохраняются даже после перехода в другие разделы.
Для сброса сделал отдельную кнопку:

![clear-filter](https://cloud.githubusercontent.com/assets/434141/7392218/1f90bb30-ee8f-11e4-97a8-95dc4944aa3a.png)

Чтобы работало, у контроллеров надо выкинуть часть кода (см. ниже) поэтому пока сделал только для одного.

```php
        $model->unsetAttributes();

        $model->setAttributes(
            Yii::app()->getRequest()->getParam(
                'Page',
                []
            )
        );
```
Если в целом нормально, то доделаю, если нет, то закрою.
Жду критики.
