### PR TITLE
Фильтрация каталога по атрибутам

### DIFF
--- a/protected/modules/store/components/AttributeFilter.php
+++ b/protected/modules/store/components/AttributeFilter.php
@@ -1,0 +1,116 @@
+<?php
+
+class AttributeFilter extends CComponent
+{
+    public $dropdownTemplate = 'fd-%s-%s';
+    public $checkboxTemplate = 'fc-%s';
+    public $numberTemplate = 'fn-%s-%s';
+
+    public $dropdownParseTemplate = '/fd-([\w_\*]+)-([\w_\*]+)/';
+    public $checkboxParseTemplate = '/fc-([\w_\*]+)/';
+    public $numberParseTemplate = '/fn-([\w_\*]+)-([\w_\*]+)/';
+
+    public function init()
+    {
+
+    }
+
+    public function getDropdownOptionName(AttributeOption $option)
+    {
+        if ($option->parent->type == Attribute::TYPE_DROPDOWN) {
+            return sprintf($this->dropdownTemplate, $option->parent->name, $option->id);
+        }
+
+        return null;
+    }
+
+    public function getIsDropdownOptionChecked(AttributeOption $option)
+    {
+        return Yii::app()->request->getParam($this->getDropdownOptionName($option), false);
+    }
+
+    public function getCheckboxName(Attribute $attribute)
+    {
+        if ($attribute->type == Attribute::TYPE_CHECKBOX) {
+            return sprintf($this->checkboxTemplate, $attribute->name);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Attribute $attribute
+     * @param $value int - 1 - да, 0 - нет, -1 - неважно
+     * @return bool
+     */
+    public function getIsCheckboxChecked(Attribute $attribute, $value = null)
+    {
+        return Yii::app()->request->getParam($this->getCheckboxName($attribute), -1) == $value;
+    }
+
+    public function getNumberName(Attribute $attribute, $mode = 'from')
+    {
+        if ($attribute->type == Attribute::TYPE_NUMBER) {
+            return sprintf($this->numberTemplate, $attribute->name, $mode);
+        }
+
+        return null;
+    }
+
+    public function getNumberValue(Attribute $attribute, $mode = 'from')
+    {
+        return Yii::app()->request->getParam($this->getNumberName($attribute, $mode), null);
+    }
+
+    /**
+     * Формирует список атрибутов для передачи в EEavBehavior->getFilterByEavAttributesCriteria
+     * @return array
+     */
+    public function getAttributesFromQuery()
+    {
+        $res = [];
+
+        $params = [];
+        parse_str(Yii::app()->request->getQueryString(), $params);
+
+        foreach ($params as $param => $value) {
+            if (is_string($param)) {
+                $matches = null;
+                if (preg_match($this->dropdownParseTemplate, $param, $matches)) {
+                    $attribute = $matches[1];
+                    $option = $matches[2];
+                    if (!isset($res[$attribute])) {
+                        $res[$attribute] = [];
+                    }
+                    $res[$attribute][] = $option;
+                } elseif (preg_match($this->checkboxParseTemplate, $param, $matches)) {
+                    $attribute = $matches[1];
+                    switch ($value) {
+                        case 1:
+                            $res[$attribute] = [1];
+                            break;
+                        case 0:
+                            $res[$attribute] = [0];
+                            break;
+                    }
+                } elseif (preg_match($this->numberParseTemplate, $param, $matches)) {
+                    if ($value == '') {
+                        continue;
+                    }
+                    $attribute = $matches[1];
+                    $mode = $matches[2];
+                    switch ($mode) {
+                        case 'from':
+                            $res[] = ['>=', $attribute, floatval($value)];
+                            break;
+                        case 'to':
+                            $res[] = ['<=', $attribute, floatval($value)];
+                            break;
+                    }
+                }
+            }
+        }
+
+        return $res;
+    }
+}

--- a/protected/modules/store/components/ProductRepository.php
+++ b/protected/modules/store/components/ProductRepository.php
@@ -11,13 +11,22 @@ class ProductRepository extends CComponent
      */
     public function getListForIndexPage($perPage = 20)
     {
+        $model = Product::model();
+        $filter = new AttributeFilter();
+
         $criteria = new CDbCriteria();
+        $criteria->select = 't.*';
         $criteria->params = [];
         $criteria->addCondition('status = :status');
         $criteria->params['status'] = Product::STATUS_ACTIVE;
 
+        $eavCriteria = $model->getFilterByEavAttributesCriteria($filter->getAttributesFromQuery());
+
+        $criteria->mergeWith($eavCriteria);
+
         return $dataProvider = new CActiveDataProvider(
-            Product::model(), [
+            $model,
+            [
                 'criteria' => $criteria,
                 'pagination' => [
                     'pageSize' => (int)$perPage,
@@ -37,16 +46,25 @@ class ProductRepository extends CComponent
      */
     public function getListForCategory(StoreCategory $category, $perPage = 20)
     {
+        $model = Product::model();
+        $filter = new AttributeFilter();
+
         $criteria = new CDbCriteria();
 
+        $criteria->select = 't.*';
         $criteria->with = ['categoryRelation' => ['together' => true]];
         $criteria->addCondition('categoryRelation.category_id = :category_id OR t.category_id = :category_id');
         $criteria->addCondition('status = :status');
         $criteria->params = CMap::mergeArray($criteria->params, [':category_id' => $category->id]);
         $criteria->params['status'] = Product::STATUS_ACTIVE;
 
+        $eavCriteria = $model->getFilterByEavAttributesCriteria($filter->getAttributesFromQuery());
+
+        $criteria->mergeWith($eavCriteria);
+
         return $dataProvider = new CActiveDataProvider(
-            Product::model(), [
+            $model,
+            [
                 'criteria' => $criteria,
                 'pagination' => [
                     'pageSize' => (int)$perPage,
@@ -67,7 +85,7 @@ class ProductRepository extends CComponent
         $criteria->params['status'] = Product::STATUS_ACTIVE;
         $criteria->addSearchCondition('name', $query, true);
 
-        if($category) {
+        if ($category) {
             $criteria->addCondition('category_id = :category');
             $criteria->params[':category'] = (int)$category;
         }

--- a/protected/modules/store/models/Attribute.php
+++ b/protected/modules/store/models/Attribute.php
@@ -148,7 +148,7 @@ class Attribute extends \yupe\models\YModel
             //self::TYPE_CHECKBOX_LIST => Yii::t('StoreModule.store', 'Список чекбоксов'),
             self::TYPE_CHECKBOX => Yii::t('StoreModule.attr', 'Checkbox'),
             //self::TYPE_IMAGE => Yii::t('StoreModule.store', 'Изображение'),
-            //self::TYPE_NUMBER => Yii::t('StoreModule.store', 'Число'),
+            self::TYPE_NUMBER => Yii::t('StoreModule.store', 'Число'),
         ];
     }
 
@@ -184,7 +184,7 @@ class Attribute extends \yupe\models\YModel
                 return CHtml::checkBoxList($name . '[]', $value, $data, $htmlOptions);
                 break;
             case self::TYPE_CHECKBOX:
-                return CHtml::checkBox($name, $value, $htmlOptions);
+                return CHtml::checkBox($name, $value, CMap::mergeArray(['uncheckValue' => 0], $htmlOptions));
                 break;
             case self::TYPE_NUMBER:
                 return CHtml::numberField($name, $value, $htmlOptions);

--- a/protected/modules/store/views/productBackend/_attribute_form.php
+++ b/protected/modules/store/views/productBackend/_attribute_form.php
@@ -1,58 +1,55 @@
-
 <?php
 /* @var $model Product - передается при рендере из формы редактирования товара */
 /* @var $type Type - передается при генерации формы через ajax */
 ?>
 
 
-<?php if($model && $model->type):?>
-<div class="row">
-    <div class="col-sm-12">
-        <?php if (is_array($model->type->typeAttributes)): ?>
-            <?php
-            $attributeGroups = [];
-            foreach ($model->type->typeAttributes as $attribute) {
-                if ($attribute->group) {
-                    $attributeGroups[$attribute->group->name][] = $attribute;
-                } else {
-                    $attributeGroups[Yii::t('StoreModule.attribute', 'Without a group')][] = $attribute;
+<?php if ($model && $model->type): ?>
+    <div class="row">
+        <div class="col-sm-12">
+            <?php if (is_array($model->type->typeAttributes)): ?>
+                <?php
+                $attributeGroups = [];
+                foreach ($model->type->typeAttributes as $attribute) {
+                    if ($attribute->group) {
+                        $attributeGroups[$attribute->group->name][] = $attribute;
+                    } else {
+                        $attributeGroups[Yii::t('StoreModule.attribute', 'Without a group')][] = $attribute;
+                    }
                 }
-            }
-            ?>
-            <?php foreach ($attributeGroups as $groupName => $items): ?>
-                <fieldset>
-                    <legend><?php echo $groupName; ?></legend>
-                    <?php foreach ($items as $attribute): ?>
-                        <?php $hasError = isset($model) ? $model->hasErrors('eav.' . $attribute->name) : false; ?>
-                        <div class="row form-group">
-                            <div class="col-sm-2">
-                                <label for="Attribute_<?= $attribute->name ?>"
-                                       class="<?php echo $hasError ? "has-error" : ""; ?>">
-                                    <?php echo $attribute->title; ?>
-                                    <?php if ($attribute->required): { ?>
-                                        <span class="required">*</span>
-                                    <?php } endif; ?>
-                                    <?php if ($attribute->unit): { ?>
-                                        <span>(<?php echo $attribute->unit; ?>)</span>
-                                    <?php } endif; ?>
-                                </label>
+                ?>
+                <?php foreach ($attributeGroups as $groupName => $items): ?>
+                    <fieldset>
+                        <legend><?php echo $groupName; ?></legend>
+                        <?php foreach ($items as $attribute): ?>
+                            <?php /* @var $attribute Attribute */ ?>
+                            <?php $hasError = isset($model) ? $model->hasErrors('eav.' . $attribute->name) : false; ?>
+                            <div class="row form-group">
+                                <div class="col-sm-2">
+                                    <label for="Attribute_<?= $attribute->name ?>"
+                                           class="<?php echo $hasError ? "has-error" : ""; ?>">
+                                        <?php echo $attribute->title; ?>
+                                        <?php if ($attribute->required): ?>
+                                            <span class="required">*</span>
+                                        <?php endif; ?>
+                                        <?php if ($attribute->unit): ?>
+                                            <span>(<?php echo $attribute->unit; ?>)</span>
+                                        <?php endif; ?>
+                                    </label>
+                                </div>
+                                <div class="col-sm-<?php echo $attribute->type == Attribute::TYPE_TEXT ? 9 : 2; ?> <?php echo $hasError ? "has-error" : ""; ?>">
+                                    <?php echo $attribute->renderField((isset($model) ? $model->attr($attribute->name) : null)); ?>
+                                </div>
                             </div>
-                            <div
-                                class="col-sm-<?php echo $attribute->type == Attribute::TYPE_TEXT ? 9 : 2; ?> <?php echo $hasError ? "has-error" : ""; ?>">
-                                <?php echo $attribute->renderField(
-                                    isset($model) ? $model->attr($attribute->name) : null
-                                ); ?>
-                            </div>
-                        </div>
-                    <?php endforeach; ?>
-                </fieldset>
-            <?php endforeach; ?>
-        <?php endif; ?>
+                        <?php endforeach; ?>
+                    </fieldset>
+                <?php endforeach; ?>
+            <?php endif; ?>
+        </div>
     </div>
-</div>
-<?php else:?>
+<?php else: ?>
     <div class="alert alert-info">
-        <?= Yii::t('StoreModule.store', 'Attributes are not added.');?>
-        <?= CHtml::link(Yii::t('StoreModule.store', 'Add them ?'), ['/store/attributeBackend/create']);?>
+        <?= Yii::t('StoreModule.store', 'Attributes are not added.'); ?>
+        <?= CHtml::link(Yii::t('StoreModule.store', 'Add them ?'), ['/store/attributeBackend/create']); ?>
     </div>
-<?php endif;?>
+<?php endif; ?>

--- a/protected/modules/store/widgets/AttributesFilterWidget.php
+++ b/protected/modules/store/widgets/AttributesFilterWidget.php
@@ -1,0 +1,26 @@
+<?php
+
+class AttributesFilterWidget extends \yupe\widgets\YWidget
+{
+    public $attributes;
+
+    public function run()
+    {
+        foreach ($this->attributes as $name) {
+            $model = Attribute::model()->findByAttributes(['name' => $name]);
+            if ($model) {
+                switch ($model->type) {
+                    case Attribute::TYPE_DROPDOWN:
+                        $this->widget('application.modules.store.widgets.DropdownFilterWidget', ['attribute' => $model]);
+                        break;
+                    case Attribute::TYPE_CHECKBOX:
+                        $this->widget('application.modules.store.widgets.CheckboxFilterWidget', ['attribute' => $model]);
+                        break;
+                    case Attribute::TYPE_NUMBER:
+                        $this->widget('application.modules.store.widgets.NumberFilterWidget', ['attribute' => $model]);
+                        break;
+                }
+            }
+        }
+    }
+} 

--- a/protected/modules/store/widgets/CheckboxFilterWidget.php
+++ b/protected/modules/store/widgets/CheckboxFilterWidget.php
@@ -1,0 +1,26 @@
+<?php
+
+class CheckboxFilterWidget extends \yupe\widgets\YWidget
+{
+    public $view = 'checkbox-filter';
+
+    public $attribute;
+
+    public function init()
+    {
+        if (is_string($this->attribute)) {
+            $this->attribute = Attribute::model()->findByAttributes(['name' => $this->attribute]);
+        }
+
+        if (!($this->attribute instanceof Attribute) || $this->attribute->type != Attribute::TYPE_CHECKBOX) {
+            throw new Exception('Атрибут не найден или неправильного типа');
+        }
+
+        parent::init();
+    }
+
+    public function run()
+    {
+        $this->render($this->view, ['attribute' => $this->attribute]);
+    }
+} 

--- a/protected/modules/store/widgets/DropdownFilterWidget.php
+++ b/protected/modules/store/widgets/DropdownFilterWidget.php
@@ -1,0 +1,26 @@
+<?php
+
+class DropdownFilterWidget extends \yupe\widgets\YWidget
+{
+    public $view = 'dropdown-filter';
+
+    public $attribute;
+
+    public function init()
+    {
+        if (is_string($this->attribute)) {
+            $this->attribute = Attribute::model()->findByAttributes(['name' => $this->attribute]);
+        }
+
+        if (!($this->attribute instanceof Attribute) || $this->attribute->type != Attribute::TYPE_DROPDOWN) {
+            throw new Exception('Атрибут не найден или неправильного типа');
+        }
+
+        parent::init();
+    }
+
+    public function run()
+    {
+        $this->render($this->view, ['attribute' => $this->attribute]);
+    }
+} 

--- a/protected/modules/store/widgets/FilterBlockWidget.php
+++ b/protected/modules/store/widgets/FilterBlockWidget.php
@@ -1,0 +1,12 @@
+<?php
+
+class FilterBlockWidget extends \yupe\widgets\YWidget
+{
+    public $view = 'filter-block';
+    public $attributes;
+
+    public function run()
+    {
+        $this->render($this->view, ['attributes' => $this->attributes]);
+    }
+} 

--- a/protected/modules/store/widgets/NumberFilterWidget.php
+++ b/protected/modules/store/widgets/NumberFilterWidget.php
@@ -1,0 +1,26 @@
+<?php
+
+class NumberFilterWidget extends \yupe\widgets\YWidget
+{
+    public $view = 'number-filter';
+
+    public $attribute;
+
+    public function init()
+    {
+        if (is_string($this->attribute)) {
+            $this->attribute = Attribute::model()->findByAttributes(['name' => $this->attribute]);
+        }
+
+        if (!($this->attribute instanceof Attribute) || $this->attribute->type != Attribute::TYPE_NUMBER) {
+            throw new Exception('Атрибут не найден или неправильного типа');
+        }
+
+        parent::init();
+    }
+
+    public function run()
+    {
+        $this->render($this->view, ['attribute' => $this->attribute]);
+    }
+} 

--- a/protected/modules/store/widgets/views/checkbox-filter.php
+++ b/protected/modules/store/widgets/views/checkbox-filter.php
@@ -1,0 +1,29 @@
+<?php
+/* @var $attribute Attribute */
+$filter = new AttributeFilter();
+?>
+<div class="filter-block-checkbox-list">
+    <div class="filter-block-header">
+        <?= $attribute->title ?>
+    </div>
+    <div class="filter-block-body">
+        <div class="radio">
+            <label>
+                <?= CHtml::radioButton($filter->getCheckboxName($attribute), $filter->getIsCheckboxChecked($attribute, 1), ['value' => 1]) ?>
+                Да
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?= CHtml::radioButton($filter->getCheckboxName($attribute), $filter->getIsCheckboxChecked($attribute, 0), ['value' => 0]) ?>
+                Нет
+            </label>
+        </div>
+        <div class="radio">
+            <label>
+                <?= CHtml::radioButton($filter->getCheckboxName($attribute), $filter->getIsCheckboxChecked($attribute, -1), ['value' => -1]) ?>
+                Неважно
+            </label>
+        </div>
+    </div>
+</div>

--- a/protected/modules/store/widgets/views/dropdown-filter.php
+++ b/protected/modules/store/widgets/views/dropdown-filter.php
@@ -1,0 +1,19 @@
+<?php
+/* @var $attribute Attribute */
+$filter = new AttributeFilter();
+?>
+<div class="filter-block-checkbox-list">
+    <div class="filter-block-header">
+        <?= $attribute->title ?>
+    </div>
+    <div class="filter-block-body">
+        <?php foreach ($attribute->options as $option): ?>
+            <div class="checkbox">
+                <label>
+                    <?= CHtml::checkBox($filter->getDropdownOptionName($option), $filter->getIsDropdownOptionChecked($option)) ?>
+                    <?= $option->value ?>
+                </label>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>

--- a/protected/modules/store/widgets/views/filter-block.php
+++ b/protected/modules/store/widgets/views/filter-block.php
@@ -1,0 +1,14 @@
+<?php
+/* @var $attributes array */
+?>
+
+<div class="filter-block">
+    <form>
+        <div class="filter-attributes">
+            <?php $this->widget('application.modules.store.widgets.AttributesFilterWidget', ['attributes' => $attributes]) ?>
+        </div>
+        <div>
+            <input type="submit"/>
+        </div>
+    </form>
+</div>

--- a/protected/modules/store/widgets/views/number-filter.php
+++ b/protected/modules/store/widgets/views/number-filter.php
@@ -1,0 +1,19 @@
+<?php
+/* @var $attribute Attribute */
+$filter = new AttributeFilter();
+?>
+<div class="filter-block-checkbox-list">
+    <div class="filter-block-header">
+        <?= $attribute->title ?>
+    </div>
+    <div class="filter-block-body">
+        <div class="row">
+            <div class="col-xs-6">
+                <?= CHtml::textField($filter->getNumberName($attribute, 'from'), $filter->getNumberValue($attribute, 'from'), ['class' => 'form-control']) ?>
+            </div>
+            <div class="col-xs-6">
+                <?= CHtml::textField($filter->getNumberName($attribute, 'to'), $filter->getNumberValue($attribute, 'to'), ['class' => 'form-control']) ?>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Добавляет в систему базовую фильтрацию товаров по атрибутам и виджеты для вывода фильтров.
Пример использования:
```php
// color - список
// new - чекбокс 
// ves - число
$this->widget('application.modules.store.widgets.FilterBlockWidget', ['attributes' => ['color', 'new', 'ves']]);
```

в итоге получаем:
![](http://i.imgur.com/9s4qFhj.png)