### PR TITLE
UserBlogsWidget стиль ссылок

### DIFF
--- a/themes/default/views/blog/widgets/UserBlogsWidget/userblogs.php
+++ b/themes/default/views/blog/widgets/UserBlogsWidget/userblogs.php
@@ -4,7 +4,8 @@
         <?php foreach ($models as $model): ?>
             <?= CHtml::link(
                 CHtml::encode($model->name),
-                ['/blog/blog/show', 'slug' => CHtml::encode($model->slug)]
+                ['/blog/blog/show', 'slug' => CHtml::encode($model->slug)],
+                ['class' => 'label label-info']
             ); ?>
         <?php endforeach; ?>
     </div>


### PR DESCRIPTION
Ссылки на блоги визуально сливаются, иногда не понятно, что это две разные ссылки.

**Было:**
![user_profile_before](https://cloud.githubusercontent.com/assets/434141/7789031/2f940688-025b-11e5-9e3f-02cc47b431f1.png)

**Стало:**
![user_profile_after](https://cloud.githubusercontent.com/assets/434141/7789034/3bb2d980-025b-11e5-9aa1-92e985537bb6.png)
