### PR TITLE
Снова верхнее меню ))

### DIFF
--- a/protected/modules/yupe/views/assets/css/styles.css
+++ b/protected/modules/yupe/views/assets/css/styles.css
@@ -301,3 +301,12 @@ input.form-control[type="file"] {
 .grid-toolbar {
     height: 40px;
 }
+
+/*navbar*/
+.navbar-default .navbar-nav>li>a {
+    padding: 15px 5px;
+}
+
+.navbar-brand {
+    padding: 7px 5px 15px 15px;
+}

--- a/protected/modules/yupe/views/widgets/YAdminPanel/adminpanel.php
+++ b/protected/modules/yupe/views/widgets/YAdminPanel/adminpanel.php
@@ -32,18 +32,12 @@ $this->widget(
             [
                 'class' => 'bootstrap.widgets.TbMenu',
                 'type'  => 'navbar',
-                'htmlOptions' => ['class' => 'visible-xs hidden-sm visible-md visible-lg'],
+                'encodeLabel' => false,
                 'items' => $modules
             ],
             [
-                'class' => 'bootstrap.widgets.TbMenu',
-                'type'  => 'navbar',
-                'htmlOptions' => ['class' => 'hidden-xs visible-sm hidden-md'],
-                'items' => $modulesMobile
-            ],
-            [
                 'class'       => 'bootstrap.widgets.TbMenu',
-                'htmlOptions' => ['class' => 'navbar-right'],
+                'htmlOptions' => ['class' => 'navbar-right visible-xs hidden-sm hidden-md visible-lg'],
                 'type'        => 'navbar',
                 'encodeLabel' => false,
                 'items'       => $navbarRight,

--- a/protected/modules/yupe/views/widgets/YAdminPanel/adminpanel.php
+++ b/protected/modules/yupe/views/widgets/YAdminPanel/adminpanel.php
@@ -16,9 +16,7 @@ $mainAssets = Yii::app()->getAssetManager()->publish(
 $this->widget(
     'bootstrap.widgets.TbNavbar',
     [
-        //'type' => 'inverse',
         'fluid'    => true,
-        'collapse' => true,
         'fixed'    => 'top',
         'brand'    => CHtml::image(
             $mainAssets . '/img/logo.png',
@@ -34,103 +32,21 @@ $this->widget(
             [
                 'class' => 'bootstrap.widgets.TbMenu',
                 'type'  => 'navbar',
+                'htmlOptions' => ['class' => 'visible-xs hidden-sm visible-md visible-lg'],
                 'items' => $modules
+            ],
+            [
+                'class' => 'bootstrap.widgets.TbMenu',
+                'type'  => 'navbar',
+                'htmlOptions' => ['class' => 'hidden-xs visible-sm hidden-md'],
+                'items' => $modulesMobile
             ],
             [
                 'class'       => 'bootstrap.widgets.TbMenu',
                 'htmlOptions' => ['class' => 'navbar-right'],
                 'type'        => 'navbar',
                 'encodeLabel' => false,
-                'items'       => array_merge(
-                    [
-                        [
-                            'icon'  => 'fa fa-fw fa-question-circle',
-                            'label' => Yii::t('YupeModule.yupe', 'Help'),
-                            'url'   => CHtml::normalizeUrl(['/yupe/backend/help']),
-                            'items' => [
-                                [
-                                    'icon'        => 'fa fa-fw fa-globe',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Official site'),
-                                    'url'         => 'http://yupe.ru?from=help',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-book',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Official docs'),
-                                    'url'         => 'http://yupe.ru/docs/index.html?from=help',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-th-large',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Additional modules'),
-                                    'url'         => 'https://github.com/yupe/yupe-ext',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-comment',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Forum'),
-                                    'url'         => 'http://yupe.ru/talk/?from=help',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-comment',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Chat'),
-                                    'url'         => 'http://gitter.im/yupe/yupe',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-globe',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Community on github'),
-                                    'url'         => 'https://github.com/yupe/yupe',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-thumbs-up',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Order development and support'),
-                                    'url'         => 'http://amylabs.ru/contact?from=help-support',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'        => 'fa fa-fw fa-warning',
-                                    'label'       => Yii::t('YupeModule.yupe', 'Report a bug'),
-                                    'url'         => 'http://yupe.ru/contacts?from=panel',
-                                    'linkOptions' => ['target' => '_blank'],
-                                ],
-                                [
-                                    'icon'  => 'fa fa-fw fa-question-circle',
-                                    'label' => Yii::t('YupeModule.yupe', 'About Yupe!'),
-                                    'url'   => ['/yupe/backend/help'],
-                                ],
-                            ]
-                        ],
-                        [
-                            'icon'  => 'fa fa-fw fa-home',
-                            'label' => Yii::t('YupeModule.yupe', 'Go home'),
-                            'url'   => Yii::app()->createAbsoluteUrl('/')
-                        ],
-                        [
-                            'icon'  => 'fa fa-fw fa-user',
-                            'label' => '<span class="label label-info">' . CHtml::encode(
-                                    Yii::app()->getUser()->getProfileField('fullName')
-                                ) . '</span>',
-                            'items' => [
-                                [
-                                    'icon'  => 'fa fa-fw fa-cog',
-                                    'label' => Yii::t('YupeModule.yupe', 'Profile'),
-                                    'url'   => CHtml::normalizeUrl(
-                                        (['/user/userBackend/update', 'id' => Yii::app()->getUser()->getId()])
-                                    ),
-                                ],
-                                [
-                                    'icon'  => 'fa fa-fw fa-power-off',
-                                    'label' => Yii::t('YupeModule.yupe', 'Exit'),
-                                    'url'   => CHtml::normalizeUrl(['/user/account/logout']),
-                                ],
-                            ],
-                        ],
-                    ],
-                    $yupe->getLanguageSelectorArray()
-                ),
+                'items'       => $navbarRight,
             ],
         ],
     ]

--- a/protected/modules/yupe/widgets/YAdminPanel.php
+++ b/protected/modules/yupe/widgets/YAdminPanel.php
@@ -28,10 +28,11 @@ class YAdminPanel extends YWidget
 
         $cached = Yii::app()->getCache()->get($cacheKey);
 
-        $modules = $modulesMobile = Yii::app()->moduleManager->getModules(true);
-        foreach($modulesMobile as &$item){
-            $item['linkOptions'] = ['title'=>$item['label']];
-            $item['label'] = '';
+        $modules = Yii::app()->moduleManager->getModules(true);
+
+        foreach ($modules as &$item) {
+            $item['linkOptions'] = ['title' => $item['label']];
+            $item['label'] = CHtml::tag('span', ['class' => 'hidden-sm'], $item['label']);
         }
 
         if (false === $cached) {
@@ -39,7 +40,6 @@ class YAdminPanel extends YWidget
                 $this->view,
                 [
                     'modules' => $modules,
-                    'modulesMobile' => $modulesMobile,
                     'navbarRight' => $this->getNavbarRight(),
                 ],
                 true
@@ -61,7 +61,7 @@ class YAdminPanel extends YWidget
             [
                 [
                     'icon'  => 'fa fa-fw fa-question-circle',
-                    'label' => Yii::t('YupeModule.yupe', 'Help'),
+                    'label' => CHtml::tag('span',['class'=>'hidden-sm hidden-md hidden-lg'],Yii::t('YupeModule.yupe', 'Help')),
                     'url'   => CHtml::normalizeUrl(['/yupe/backend/help']),
                     'items' => [
                         [
@@ -121,7 +121,7 @@ class YAdminPanel extends YWidget
                 ],
                 [
                     'icon'  => 'fa fa-fw fa-home',
-                    'label' => Yii::t('YupeModule.yupe', 'Go home'),
+                    'label' => CHtml::tag('span',['class'=>'hidden-sm hidden-md hidden-lg'],Yii::t('YupeModule.yupe', 'Go home')),
                     'url'   => Yii::app()->createAbsoluteUrl('/')
                 ],
                 [

--- a/protected/modules/yupe/widgets/YAdminPanel.php
+++ b/protected/modules/yupe/widgets/YAdminPanel.php
@@ -28,12 +28,19 @@ class YAdminPanel extends YWidget
 
         $cached = Yii::app()->getCache()->get($cacheKey);
 
+        $modules = $modulesMobile = Yii::app()->moduleManager->getModules(true);
+        foreach($modulesMobile as &$item){
+            $item['linkOptions'] = ['title'=>$item['label']];
+            $item['label'] = '';
+        }
+
         if (false === $cached) {
             $cached = $this->render(
                 $this->view,
                 [
-                    'modules' => Yii::app()->moduleManager->getModules(true),
-                    'yupe' => $this->getController()->yupe
+                    'modules' => $modules,
+                    'modulesMobile' => $modulesMobile,
+                    'navbarRight' => $this->getNavbarRight(),
                 ],
                 true
             );
@@ -46,5 +53,99 @@ class YAdminPanel extends YWidget
         }
 
         echo $cached;
+    }
+
+    private function getNavbarRight()
+    {
+        return array_merge(
+            [
+                [
+                    'icon'  => 'fa fa-fw fa-question-circle',
+                    'label' => Yii::t('YupeModule.yupe', 'Help'),
+                    'url'   => CHtml::normalizeUrl(['/yupe/backend/help']),
+                    'items' => [
+                        [
+                            'icon'        => 'fa fa-fw fa-globe',
+                            'label'       => Yii::t('YupeModule.yupe', 'Official site'),
+                            'url'         => 'http://yupe.ru?from=help',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-book',
+                            'label'       => Yii::t('YupeModule.yupe', 'Official docs'),
+                            'url'         => 'http://yupe.ru/docs/index.html?from=help',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-th-large',
+                            'label'       => Yii::t('YupeModule.yupe', 'Additional modules'),
+                            'url'         => 'https://github.com/yupe/yupe-ext',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-comment',
+                            'label'       => Yii::t('YupeModule.yupe', 'Forum'),
+                            'url'         => 'http://yupe.ru/talk/?from=help',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-comment',
+                            'label'       => Yii::t('YupeModule.yupe', 'Chat'),
+                            'url'         => 'http://gitter.im/yupe/yupe',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-globe',
+                            'label'       => Yii::t('YupeModule.yupe', 'Community on github'),
+                            'url'         => 'https://github.com/yupe/yupe',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-thumbs-up',
+                            'label'       => Yii::t('YupeModule.yupe', 'Order development and support'),
+                            'url'         => 'http://amylabs.ru/contact?from=help-support',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'        => 'fa fa-fw fa-warning',
+                            'label'       => Yii::t('YupeModule.yupe', 'Report a bug'),
+                            'url'         => 'http://yupe.ru/contacts?from=panel',
+                            'linkOptions' => ['target' => '_blank'],
+                        ],
+                        [
+                            'icon'  => 'fa fa-fw fa-question-circle',
+                            'label' => Yii::t('YupeModule.yupe', 'About Yupe!'),
+                            'url'   => ['/yupe/backend/help'],
+                        ],
+                    ]
+                ],
+                [
+                    'icon'  => 'fa fa-fw fa-home',
+                    'label' => Yii::t('YupeModule.yupe', 'Go home'),
+                    'url'   => Yii::app()->createAbsoluteUrl('/')
+                ],
+                [
+                    'icon'  => 'fa fa-fw fa-user',
+                    'label' => '<span class="label label-info">' . CHtml::encode(
+                            Yii::app()->getUser()->getProfileField('fullName')
+                        ) . '</span>',
+                    'items' => [
+                        [
+                            'icon'  => 'fa fa-fw fa-cog',
+                            'label' => Yii::t('YupeModule.yupe', 'Profile'),
+                            'url'   => CHtml::normalizeUrl(
+                                (['/user/userBackend/update', 'id' => Yii::app()->getUser()->getId()])
+                            ),
+                        ],
+                        [
+                            'icon'  => 'fa fa-fw fa-power-off',
+                            'label' => Yii::t('YupeModule.yupe', 'Exit'),
+                            'url'   => CHtml::normalizeUrl(['/user/account/logout']),
+                        ],
+                    ],
+                ],
+            ],
+            $this->getController()->yupe->getLanguageSelectorArray()
+        );
     }
 }


### PR DESCRIPTION
Переработка верхнего меню для корректного отображения на маленьких экранах

![-768](https://cloud.githubusercontent.com/assets/2697129/8356576/d785a5ec-1b5e-11e5-9495-bf1ae0ee4dad.jpg)
![768-992](https://cloud.githubusercontent.com/assets/2697129/8356578/d789efa8-1b5e-11e5-8b34-485fe51dcf59.jpg)
![992-](https://cloud.githubusercontent.com/assets/2697129/8356577/d786e60a-1b5e-11e5-91c1-391b269688c7.jpg)

Реализовано:
- уменьшены отступы пунктов меню слева и справа
- убрано "'collapse' => true," , так как по умолчанию true
- выводиться дополнительное меню только с пустым label. Данное меню используется для отображения на экранах с шириной 768px - 992px