### PR TITLE
Корзина зависит от модуля "Купоны"

### DIFF
--- a/protected/modules/cart/CartModule.php
+++ b/protected/modules/cart/CartModule.php
@@ -10,7 +10,7 @@ class CartModule extends WebModule
 
     public function getDependencies()
     {
-        return ['order'];
+        return ['order', 'coupon'];
     }
 
     public function getEditableParams()


### PR DESCRIPTION
Если не устанавливать модуль "Купоны", получаем ошибки о несуществущем методе