### PR TITLE
Ошибка отображения товаров с дополнительными категориями

### DIFF
--- a/protected/modules/store/components/ProductRepository.php
+++ b/protected/modules/store/components/ProductRepository.php
@@ -176,6 +176,7 @@ class ProductRepository extends CComponent
         $criteria->with = ['categoryRelation' => ['together' => true]];
         $criteria->addCondition('categoryRelation.category_id = :category_id OR t.category_id = :category_id');
         $criteria->addCondition('status = :status');
+        $criteria->group = 't.id';
         $criteria->params = CMap::mergeArray($criteria->params, [':category_id' => $category->id]);
         $criteria->params['status'] = Product::STATUS_ACTIVE;
 

--- a/protected/modules/store/models/Product.php
+++ b/protected/modules/store/models/Product.php
@@ -289,6 +289,7 @@ class Product extends yupe\models\YModel implements ICommentable
         if ($this->category) {
             $criteria->with = ['categoryRelation' => ['together' => true]];
             $criteria->addCondition('categoryRelation.category_id = :category_id OR t.category_id = :category_id');
+            $criteria->group = 't.id';
             $criteria->params = CMap::mergeArray($criteria->params, [':category_id' => $this->category]);
         }
 


### PR DESCRIPTION
Если у товара есть дополнительная категория, то в админке и на фронте выводится неправильное количество товаров и творится неведомая ерунда с пагинатором.