### PR TITLE
Отображение скрытых категорий в админке

### DIFF
--- a/protected/modules/store/controllers/CategoryController.php
+++ b/protected/modules/store/controllers/CategoryController.php
@@ -24,7 +24,7 @@ class CategoryController extends FrontController
     public function actionIndex()
     {
         $this->render('index', [
-            'dataProvider' => new CArrayDataProvider(StoreCategory::model()->getMenuList(1), [
+            'dataProvider' => new CArrayDataProvider(StoreCategory::model()->published()->getMenuList(1), [
                 'id' => 'id',
                 'pagination' => false
             ]),

--- a/protected/modules/store/models/StoreCategory.php
+++ b/protected/modules/store/models/StoreCategory.php
@@ -101,8 +101,6 @@ class StoreCategory extends \yupe\models\YModel
                 'parentRelation'       => 'parent',
                 'iconAttribute'        => 'categoryThumb',
                 'defaultCriteria'      => [
-                    'condition' => 'status = :status',
-                    'params'    => [':status' => self::STATUS_PUBLISHED],
                     'order'     => 't.sort'
                 ],
                 'useCache'             => true,

--- a/protected/modules/store/widgets/CategoryWidget.php
+++ b/protected/modules/store/widgets/CategoryWidget.php
@@ -24,7 +24,7 @@ class CategoryWidget extends yupe\widgets\YWidget
     public function run()
     {
         $this->render($this->view,  [
-            'tree' => (new StoreCategory())->getMenuList($this->depth, $this->parent),
+            'tree' => (new StoreCategory())->published()->getMenuList($this->depth, $this->parent),
             'htmlOptions' => $this->htmlOptions
         ]);
     }


### PR DESCRIPTION
Удобно для организации служебных категорий, которые не отображаются в меню каталога на фронте.