### PR TITLE
Исправление issue #2535

### DIFF
--- a/protected/modules/menu/models/MenuItem.php
+++ b/protected/modules/menu/models/MenuItem.php
@@ -276,7 +276,7 @@ class MenuItem extends yupe\models\YModel
      */
     public function getParentTree()
     {
-        return array_merge([Yii::t('MenuModule.menu', 'Menu root')], $this->getParentTreeIterator());
+        return [Yii::t('MenuModule.menu', 'Menu root')] + $this->getParentTreeIterator();
     }
 
     /**


### PR DESCRIPTION
#2535 array_merge пересортирует массивы с числовыми ключами с нуля, из-за этого возникает ошибка, заменил на +