### PR TITLE
fix #2542

### DIFF
--- a/protected/modules/feedback/components/EmailFeedbackSender.php
+++ b/protected/modules/feedback/components/EmailFeedbackSender.php
@@ -3,7 +3,7 @@
 /**
  * Class EmailFeedbackSender
  */
-class EmailFeedbackSender extends DbFeedbackSender implements IFeedbackSender
+class EmailFeedbackSender extends DbFeedbackSender
 {
     /**
      * @param IFeedbackForm $form
@@ -13,8 +13,15 @@ class EmailFeedbackSender extends DbFeedbackSender implements IFeedbackSender
     {
         $emailBody = Yii::app()->getController()->renderPartial('feedbackEmail', ['model' => $form], true);
 
-        foreach (explode(',', $this->module->emails) as $mail) {
-            $this->mail->send($form->getEmail(), $mail, $form->getTheme(), $emailBody);
+        foreach (explode(',', $this->module->emails) as $email) {
+            $this->mail->send(
+                $this->module->notifyEmailFrom,
+                $email,
+                $form->getTheme(),
+                $emailBody,
+                false,
+                [$form->getEmail() => $form->getName()]
+            );
         }
 
         if ($this->module->sendConfirmation) {

--- a/protected/modules/queue/commands/YQueueMailSenderCommand.php
+++ b/protected/modules/queue/commands/YQueueMailSenderCommand.php
@@ -82,8 +82,10 @@ class YQueueMailSenderCommand extends ConsoleCommand
             }
 
             $from = $this->from ? $this->from : $data['from'];
+            $replyTo = isset($data['replyTo']) ? $data['replyTo'] : [];
+            $sender = Yii::app()->getComponent($this->sender);
 
-            if (Yii::app()->getComponent($this->sender)->send($from, $data['to'], $data['theme'], $data['body'])) {
+            if ($sender->send($from, $data['to'], $data['theme'], $data['body'], false, $replyTo)) {
                 $model->complete();
 
                 $this->log("Success send mail");

--- a/protected/modules/queue/components/YQueueMail.php
+++ b/protected/modules/queue/components/YQueueMail.php
@@ -56,7 +56,7 @@ class YQueueMail extends yupe\components\Mail
      * @return mixed
      * @throws Exception
      */
-    public function send($from, $to, $theme, $body, $isText = false)
+    public function send($from, $to, $theme, $body, $isText = false, $replyTo = [])
     {
         return $this->getQueueComponent()->add(
             $this->queueMailWorkerId,
@@ -65,6 +65,7 @@ class YQueueMail extends yupe\components\Mail
                 'to' => $to,
                 'theme' => $theme,
                 'body' => $body,
+                'replyTo' => $replyTo
             ]
         );
     }

--- a/protected/modules/yupe/components/Mail.php
+++ b/protected/modules/yupe/components/Mail.php
@@ -151,10 +151,11 @@ class Mail extends CApplicationComponent
      * @param string $theme - тема письма
      * @param string $body - тело письма
      * @param bool $isText - является ли тело письма текстом
+     * @param array $replyTo добавляет заголовок Reply-To, формат [email => имя]
      *
      * @return bool отправилось ли письмо
      **/
-    public function send($from, $to, $theme, $body, $isText = false)
+    public function send($from, $to, $theme, $body, $isText = false, $replyTo = [])
     {
         $this->_mailer->clearAllRecipients();
 
@@ -175,6 +176,13 @@ class Mail extends CApplicationComponent
             $this->_mailer->isHTML(false);
         } else {
             $this->_mailer->msgHTML($body, \Yii::app()->basePath);
+        }
+
+        if (!empty($replyTo)) {
+            $this->_mailer->clearReplyTos();
+            foreach ($replyTo as $email => $name) {
+                $this->_mailer->addReplyTo($email, $name);
+            }
         }
 
         try {


### PR DESCRIPTION
Добавил возможность указать заголовок replyTo для немедленной отправки так для очереди. 
Убрал отправление от имени написавшего. 

Можно было обойтись без дополнительного аргумента в методе ```send```, но не будет работать с отправкой через очередь. 