### PR TITLE
SEF pagination news

### DIFF
--- a/protected/modules/news/install/news.php
+++ b/protected/modules/news/install/news.php
@@ -35,6 +35,7 @@ return [
         ]
     ],
     'rules' => [
+        '/news/<News_page:\d+>' => 'news/news/index',
         '/news/' => 'news/news/index',
         '/news/categories' => 'news/newsCategory/index',
         [


### PR DESCRIPTION
Переделан роутинг страниц новстей, в текушем варианте(?News_page=#) оказалось яндексРобот начал видеть как дубли главной стр(/news), по сему было принято решение выводить страницы в виде ЧПУ.

Есть вероятность что у человека будет новость с именем 'news/1'
Для нас это было не критично, по этому пришел к самому короткому url с номером стр.(/news/<News_page:\d+>), если потребуется модернизировать, просто допишите в путь нужную статическую приставку

С уважением Ваш JS