### PR TITLE
fix transaction error

### DIFF
--- a/protected/modules/store/models/Product.php
+++ b/protected/modules/store/models/Product.php
@@ -772,6 +772,7 @@ class Product extends yupe\models\YModel implements ICommentable
                 return true;
             }
 
+			$transaction->rollback();
             return false;
         } catch (Exception $e) {
             $transaction->rollback();


### PR DESCRIPTION
При ошибке в методе save() без выбрасывания исключений, транзакция не завершалась.