### PR TITLE
set_time_limit(180) gives error

### DIFF
--- a/protected/modules/install/controllers/DefaultController.php
+++ b/protected/modules/install/controllers/DefaultController.php
@@ -766,8 +766,6 @@ class DefaultController extends yupe\components\controllers\BackController
      **/
     public function actionModulesinstall()
     {
-        set_time_limit(180);
-
         $error = false;
 
         $modules = Yii::app()->moduleManager->getModulesDisabled();


### PR DESCRIPTION
CDbException

CDbConnection failed to open the DB connection: SQLSTATE[HY000] [1045] Access denied for user ''@'localhost' (using password: YES) (/var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/db/CDbConnection.php:399)

#0 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/db/CDbConnection.php(347): CDbConnection->open()
#1 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/db/CDbConnection.php(325): CDbConnection->setActive(true)
#2 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CModule.php(394): CDbConnection->init()
#3 /var/www/vhosts/cms-test/yupe/protected/modules/yupe/components/Migrator.php(392): CModule->getComponent('db')
#4 /var/www/vhosts/cms-test/yupe/protected/modules/yupe/components/Migrator.php(51): yupe\components\Migrator->getDbConnection()
#5 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CModule.php(394): yupe\components\Migrator->init()
#6 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CModule.php(103): CModule->getComponent('migrator')
#7 /var/www/vhosts/cms-test/yupe/protected/modules/yupe/components/controllers/BackController.php(104): CModule->__get('migrator')
#8 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(306): yupe\components\controllers\BackController->beforeAction(Object(CInlineAction))
#9 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/filters/CFilterChain.php(134): CController->runAction(Object(CInlineAction))
#10 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(291): CFilterChain->run()
#11 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(265): CController->runActionWithFilters(Object(CInlineAction), Array)
#12 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CWebApplication.php(282): CController->run('error')
#13 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CErrorHandler.php(368): CWebApplication->runController('/yupe/backend/e...')
#14 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CErrorHandler.php(296): CErrorHandler->renderError()
#15 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CErrorHandler.php(133): CErrorHandler->handleError(Object(CErrorEvent))
#16 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CApplication.php(834): CErrorHandler->handle(Object(CErrorEvent))
#17 [internal function]: CApplication->handleError(2, 'set_time_limit(...', '/var/www/vhosts...', 769, Array)
#18 /var/www/vhosts/cms-test/yupe/protected/modules/install/controllers/DefaultController.php(769): set_time_limit(180)
#19 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/actions/CInlineAction.php(49): DefaultController->actionModulesinstall()
#20 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(308): CInlineAction->runWithParams(Array)
#21 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(286): CController->runAction(Object(CInlineAction))
#22 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CController.php(265): CController->runActionWithFilters(Object(CInlineAction), Array)
#23 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CWebApplication.php(282): CController->run('modulesinstall')
#24 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/web/CWebApplication.php(141): CWebApplication->runController('install/default...')
#25 /var/www/vhosts/cms-test/yupe/vendor/yiisoft/yii/framework/base/CApplication.php(185): CWebApplication->processRequest()
#26 /var/www/vhosts/cms-test/yupe/public/index.php(39): CApplication->run()
#27 {main}